### PR TITLE
No argument room cmd w/o file go to default room

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -217,6 +217,7 @@ class SyncplayClientManager(object):
         if(room == None or room == ''):
             room = 'default'
         self.users.currentUser.room = room
+        self.defaultRoom = room
         if(password):
             password = hashlib.md5(password).hexdigest()
         self.serverPassword = password

--- a/syncplay/ui/consoleUI.py
+++ b/syncplay/ui/consoleUI.py
@@ -72,7 +72,10 @@ class ConsoleUI(threading.Thread):
         elif matched_room:
             room = matched_room.group(2)
             if room == None:
-                room = self._syncplayClient.users.currentUser.filename
+                if  self._syncplayClient.users.currentUser.filename <> None:
+                    room = self._syncplayClient.users.currentUser.filename
+                else:
+                    room = self._syncplayClient.defaultRoom
             self._syncplayClient.users.currentUser.room = room
             self._syncplayClient.checkIfFileMatchesOthers()
             self._syncplayClient.protocol.sender.send_room(room)


### PR DESCRIPTION
Currently using the room command without arguments will cause an error
if no file has been opened. This will make it go to the default room
(i.e. the room you joined when you first connected).
