### PR TITLE
added a rewind on desync option

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -209,7 +209,7 @@ class SyncplayClient(object):
         self._lastGlobalUpdate = time.time()
         if (doSeek):
             madeChangeOnPlayer = self._serverSeeked(position, setBy)
-        if (diff > constants.REWIND_THRESHOLD and not doSeek):
+        if (diff > constants.REWIND_THRESHOLD and not doSeek and not self._config['rewindOnDesync'] == False):
             madeChangeOnPlayer = self._rewindPlayerDueToTimeDifference(position, setBy)
         if (self._player.speedSupported and not doSeek and not paused and not self._config['slowOnDesync'] == False):
             madeChangeOnPlayer = self._slowDownToCoverTimeDifference(diff, setBy)

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -34,6 +34,7 @@ class ConfigurationGetter(object):
                         "playerArgs": [],
                         "playerClass": None,
 						"slowOnDesync": True,
+                        "rewindOnDesync": True,
                         "malUsername": "",
                         "malPassword": ""
                         }
@@ -55,12 +56,13 @@ class ConfigurationGetter(object):
                          "forceGuiPrompt",
                          "noGui",
                          "noStore",
-                         "slowOnDesync"
+                         "slowOnDesync",
+                         "rewindOnDesync"
                         ]
 
         self._iniStructure = {
                         "server_data": ["host", "port", "password"],
-                        "client_settings": ["name", "room", "playerPath", "slowOnDesync", "forceGuiPrompt"],
+                        "client_settings": ["name", "room", "playerPath", "slowOnDesync", "rewindOnDesync", "forceGuiPrompt"],
                         "mal": ["malPassword", "malUsername"]
                         }
 

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -169,6 +169,10 @@ class ConfigDialog(QtGui.QDialog):
             self.config['slowOnDesync'] = True
         else:
             self.config['slowOnDesync'] = False
+        if self.rewindCheckbox.isChecked() == True:
+            self.config['rewindOnDesync'] = True
+        else:
+            self.config['rewindOnDesync'] = False
         self.config['malUsername'] = self.malusernameTextbox.text()
         if self.malSettingsGroup.isChecked():
             self.config['malPassword'] = self.malpasswordTextbox.text()
@@ -261,6 +265,7 @@ class ConfigDialog(QtGui.QDialog):
         self.mediabrowseButton = QtGui.QPushButton(QtGui.QIcon(resourcespath + 'folder_explore.png'),"Browse")
         self.mediabrowseButton.clicked.connect(self.browseMediapath)
         self.slowdownCheckbox = QCheckBox("Slow down on desync")
+        self.rewindCheckbox = QCheckBox("Rewind on desync")
         self.mediaplayerSettingsLayout = QtGui.QGridLayout()
         self.mediaplayerSettingsLayout.addWidget(self.executablepathLabel, 0, 0)
         self.mediaplayerSettingsLayout.addWidget(self.executablepathCombobox , 0, 1)
@@ -269,9 +274,12 @@ class ConfigDialog(QtGui.QDialog):
         self.mediaplayerSettingsLayout.addWidget(self.mediapathTextbox , 1, 1)
         self.mediaplayerSettingsLayout.addWidget(self.mediabrowseButton , 1, 2)
         self.mediaplayerSettingsLayout.addWidget(self.slowdownCheckbox, 2, 0)
+        self.mediaplayerSettingsLayout.addWidget(self.rewindCheckbox, 3, 0)
         self.mediaplayerSettingsGroup.setLayout(self.mediaplayerSettingsLayout)
         if config['slowOnDesync'] == True:
             self.slowdownCheckbox.setChecked(True)
+        if config['rewindOnDesync'] == True:
+            self.rewindCheckbox.setChecked(True)
 
         self.malSettingsGroup = QtGui.QGroupBox("Enable MyAnimeList updater (EXPERIMENTAL)")
         self.malSettingsGroup.setCheckable(True)


### PR DESCRIPTION
Hey, I love Syncplay. Thanks for making it :)

I use it often with friends, but the problem is that I have a pretty slow connection. If anyone on my LAN does any minor thing, it'll lag my connection to syncplay. This causes frequent slowdowns and rewinds, even though as far as I know we're still in sync (it's just interpreted as desync due to the lag).

I was glad to see an option for 'slow on desync' in 1.2.7 so that we could disable that, but the most jarring of all to us is rewind on desync. Just yesterday, for example, I was lagging so bad that all three of us who were watching a 1 hr 48 minute movie ended up taking much longer to actually finish it because we all kept getting rewinded since they were misinterpreted as being out of sync with me (or vice versa) because of the lag on my connection.

So I added a 'rewind on desync' option. I've tried it so far (by downloading something myself while syncplaying, thereby lagging myself) and it seems to work perfectly.

I think it'd be nice to have this option in Syncplay, as it would complement the 'slow on desync' option well, and it took only a little bit of code to implement (mostly mirroring the 'slow on desync' implementation).

My friends and I are going to be using this modification/patch as sync playing can be unbearable (on slow connections) without it. I just figured I'd attempt to contribute it back.

Thanks again!
