### PR TITLE
Convert the 'ShowMoreSettings' config value to a string before reading it.

### DIFF
--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -150,7 +150,7 @@ class ConfigDialog(QtGui.QDialog):
     def getMoreState(self):
         settings = QSettings("Syncplay", "MoreSettings")
         settings.beginGroup("MoreSettings")
-        morestate = unicode.lower(settings.value("ShowMoreSettings", "false"))
+        morestate = unicode.lower(unicode(settings.value("ShowMoreSettings", "false")))
         settings.endGroup()
         if morestate == "true":
             return(True)


### PR DESCRIPTION
The 'ShowMoreSettings' GUI configuration file can be saved as a boolean.
This causes a TypeError when we try to retrieve the lower case string.
