### PR TITLE
make syncplay packageable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ BASE_PATH	= /usr
 LOCAL_PATH	= ~/.local
 
 ifeq ($(SINGLE_USER),false)
-	BIN_PATH          = $(BASE_PATH)/bin
-	LIB_PATH          = $(BASE_PATH)/lib
-	APP_SHORTCUT_PATH = $(BASE_PATH)/share/applications
-	SHARE_PATH        = $(BASE_PATH)/share
+	BIN_PATH          = ${PREFIX}$(BASE_PATH)/bin
+	LIB_PATH          = ${PREFIX}$(BASE_PATH)/lib
+	APP_SHORTCUT_PATH = ${PREFIX}$(BASE_PATH)/share/applications
+	SHARE_PATH        = ${PREFIX}$(BASE_PATH)/share
 else
 	BIN_PATH          = $(LOCAL_PATH)/syncplay
 	LIB_PATH          = $(LOCAL_PATH)/syncplay
@@ -23,6 +23,9 @@ common:
 	-mkdir -p $(LIB_PATH)/syncplay/resources/
 	-mkdir -p $(LIB_PATH)/syncplay/resources/lua
 	-mkdir -p $(LIB_PATH)/syncplay/resources/lua/intf
+	-mkdir -p $(APP_SHORTCUT_PATH)
+	-mkdir -p $(SHARE_PATH)/app-install/icons
+	-mkdir -p $(SHARE_PATH)/pixmaps/
 	cp -r syncplay $(LIB_PATH)/syncplay/
 	chmod 755 $(LIB_PATH)/syncplay/
 	cp -r resources/hicolor $(SHARE_PATH)/icons/
@@ -39,8 +42,8 @@ u-common:
 
 client:
 	-mkdir -p $(BIN_PATH)
-	touch $(BIN_PATH)/syncplay
-	echo '#!/bin/sh\npython -OO $(LIB_PATH)/syncplay/syncplayClient.py "$$@"' > $(BIN_PATH)/syncplay
+	cp syncplayClient.py $(BIN_PATH)/syncplay
+	sed -i -e 's%# libpath%site.addsitedir\("$(BASE_PATH)/lib/syncplay"\)%' $(BIN_PATH)/syncplay
 	chmod 755 $(BIN_PATH)/syncplay
 	cp syncplayClient.py $(LIB_PATH)/syncplay/
 	cp resources/syncplay.desktop $(APP_SHORTCUT_PATH)/
@@ -58,8 +61,8 @@ u-client:
 
 server:
 	-mkdir -p $(BIN_PATH)
-	touch $(BIN_PATH)/syncplay-server
-	echo '#!/bin/sh\npython -OO $(LIB_PATH)/syncplay/syncplayServer.py "$$@"' > $(BIN_PATH)/syncplay-server
+	cp syncplayServer.py $(BIN_PATH)/syncplay-server
+	sed -i -e 's%# libpath%site.addsitedir\("$(BASE_PATH)/lib/syncplay"\)%' $(BIN_PATH)/syncplay-server
 	chmod 755 $(BIN_PATH)/syncplay-server
 	cp syncplayServer.py $(LIB_PATH)/syncplay/
 	cp resources/syncplay-server.desktop $(APP_SHORTCUT_PATH)/

--- a/syncplayClient.py
+++ b/syncplayClient.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
+import site
+
+# libpath
+
 from syncplay.clientManager import SyncplayClientManager
 from syncplay.utils import blackholeStdoutForFrozenWindow
+
 if(__name__ == '__main__'):
     blackholeStdoutForFrozenWindow()
     SyncplayClientManager().run()

--- a/syncplayServer.py
+++ b/syncplayServer.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 #coding:utf8
 
+import site
+
+# libpath
+
 from twisted.internet import reactor
 
 from syncplay.server import SyncFactory, SyncIsolatedFactory, ConfigurationGetter


### PR DESCRIPTION
This is just an idea I guess, but I tested it and it works both with regular `sudo make install` as well as the package that I created. Fixes #28

There's now a marker in the client and server that is just `# libpath` which gets substituted in the makefile with sed to `site.addsitedir` with the path to the syncplay module files, effectively adding the syncplay module files in `whatever/lib` to the files that python searches for during an `import`.

So yeah, I tested it and it works fine on its own (i.e. regular `sudo make install`). All I do on my own end with the arch package is yet again run sed to replace python with python2 in the client and the server. This is expected/common in arch packages for python programs.

I tried to change as little as possible. I had to add `${PREFIX}` to each of the path variables because the arch package needs some way to specify the prefix at which to install the stuff. This is otherwise empty (if the user doesn't specify it) so it should be of no consequence to anyone else.

A last minor note is that I do the replacement with sed after the file has been copied to its installation, to preserve a pristine copy in the source directory.

**EDIT**: Forgot to mention that I also `mkdir -p` some directories that hadn't been before. I suppose they weren't `mkdir -p`'d before because these directories are normally present, but the packaging system on arch does the installation within a chroot environment, where these directories don't exist, so the `mkdir -p` is necessary and of course of no consequence to anyone else if they already do exist.
