### PR TITLE
Fixed Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-SINGLE_USER	= true
+SINGLE_USER	= false
 
 ifndef VLC_SUPPORT
-	VLC_SUPPORT = false
+	VLC_SUPPORT = true
 endif
 
 ifeq ($(SINGLE_USER),false)


### PR DESCRIPTION
I found that the Makefile would fail to provide $(BIN_PATH)/syncplay with a correct location for the libs when doing a single user installation. I also think having a similar scheme inside ~/.local to that outside it to be preferable. 
