### PR TITLE
prefix vlc lib path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 ifeq ($(SINGLE_USER),false)
 	BASE_PATH    = /usr
-	VLC_LIB_PATH = /usr/lib
+	VLC_LIB_PATH = ${PREFIX}/usr/lib
 else
 	BASE_PATH    = ${HOME}/.local
 	VLC_LIB_PATH = ${HOME}/.local/share


### PR DESCRIPTION
HEAD is no longer packageable because the `VLC_LIB_PATH` variable in the makefile wasn't prefixed. This simple change prefixes the variable.
