### PR TITLE
Stop using --slave-broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 *.py[co]
 .*.sw[po]
+*.exe
 venv
 
 /SyncPlay.egg-info
 /build
 /dist
+/syncplay v*
+syncplay_setup.nsi
 dist.7z
 .*

--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -134,10 +134,8 @@ USERLIST_GUI_USERNAME_OFFSET = 21 # Pixels
 
 MPLAYER_SLAVE_ARGS = ['-slave', '--hr-seek=always', '-nomsgcolor', '-msglevel', 'all=1:global=4:cplayer=4', '-af', 'scaletempo']
 # --quiet works with both mpv 0.2 and 0.3
-MPV_SLAVE_ARGS = ['--force-window','--idle','--hr-seek=always', '--quiet', '--keep-open', '-af', 'scaletempo']
-MPV_SLAVE_ARGS_WINDOWS = ['--slave-broken']
-MPV_SLAVE_ARGS_NONWINDOWS = ['--input-terminal=no','--input-file=/dev/stdin']
-MPV_SLAVE_ARGS_NEW = ['--term-playing-msg=<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=length}\nANS_path=${path}\n</SyncplayUpdateFile>','--terminal=yes']
+MPV_SLAVE_ARGS = ['--force-window', '--idle', '--hr-seek=always', '--quiet', '--keep-open', '--af=scaletempo', '--input-terminal=no', '--input-file=/dev/stdin']
+MPV_SLAVE_ARGS_NEW = ['--term-playing-msg=<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=length}\nANS_path=${path}\n</SyncplayUpdateFile>', '--terminal=yes']
 MPV_NEW_VERSION = False
 VLC_SLAVE_ARGS = ['--extraintf=luaintf', '--lua-intf=syncplay', '--no-quiet', '--no-input-fast-seek',
                   '--play-and-pause', '--start-time=0']

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -15,7 +15,7 @@ class MpvPlayer(MplayerPlayer):
             ver = MpvPlayer.RE_VERSION.search(subprocess.check_output([playerPath, '--version']))
         except:
             ver = None
-        constants.MPV_NEW_VERSION = ver is None or int(ver.group(1)) > 0 or int(ver.group(2)) >= 5
+        constants.MPV_NEW_VERSION = ver is None or int(ver.group(1)) > 0 or int(ver.group(2)) >= 6
         if constants.MPV_NEW_VERSION:
             return NewMpvPlayer(client, MpvPlayer.getExpandedPath(playerPath), filePath, args)
         else:
@@ -24,12 +24,8 @@ class MpvPlayer(MplayerPlayer):
     @staticmethod
     def getStartupArgs(path):
         args = constants.MPV_SLAVE_ARGS
-        if constants.MPV_NEW_VERSION or sys.platform.startswith('win'):
+        if constants.MPV_NEW_VERSION:
             args.extend(constants.MPV_SLAVE_ARGS_NEW)
-        if sys.platform.startswith('win') or not constants.MPV_NEW_VERSION:
-             args.extend(constants.MPV_SLAVE_ARGS_WINDOWS)
-        else:
-             args.extend(constants.MPV_SLAVE_ARGS_NONWINDOWS)
         return args
 
     @staticmethod


### PR DESCRIPTION
mpv finally dropped --slave-broken, so Syncplay on Windows needs this change to work.