### PR TITLE
Don't overwrite user arguments with our style defaults

### DIFF
--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -134,9 +134,9 @@ USERLIST_GUI_USERNAME_OFFSET = 21 # Pixels
 USERLIST_GUI_USERNAME_COLUMN = 0
 USERLIST_GUI_FILENAME_COLUMN = 3
 
-MPLAYER_SLAVE_ARGS = ['-slave', '--hr-seek=always', '-nomsgcolor', '-msglevel', 'all=1:global=4:cplayer=4', '-af', 'scaletempo']
-# --quiet works with both mpv 0.2 and 0.3
-MPV_SLAVE_ARGS = ['--force-window', '--idle', '--hr-seek=always', '--quiet', '--keep-open', '--af-add=scaletempo', '--input-terminal=no', '--input-file=/dev/stdin']
+MPLAYER_SLAVE_ARGS = ['-slave', '--hr-seek=always', '-nomsgcolor', '-msglevel', 'all=1:global=4:cplayer=4', '-af-add', 'scaletempo']
+MPV_ARGS = ['--force-window', '--idle', '--hr-seek=always', '--keep-open', '--af-add=scaletempo']
+MPV_SLAVE_ARGS = ['--quiet', '--input-terminal=no', '--input-file=/dev/stdin']
 MPV_SLAVE_ARGS_NEW = ['--term-playing-msg=<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=length}\nANS_path=${path}\n</SyncplayUpdateFile>', '--terminal=yes']
 MPV_NEW_VERSION = False
 VLC_SLAVE_ARGS = ['--extraintf=luaintf', '--lua-intf=syncplay', '--no-quiet', '--no-input-fast-seek',

--- a/syncplay/players/mplayer.py
+++ b/syncplay/players/mplayer.py
@@ -207,8 +207,12 @@ class MplayerPlayer(BasePlayer):
         return constants.MPLAYER_ICONPATH
 
     @staticmethod
-    def getStartupArgs(path):
-        return constants.MPLAYER_SLAVE_ARGS
+    def getStartupArgs(path, userArgs):
+        args = []
+        if userArgs:
+            args.extend(userArgs)
+        args.extend(constants.MPLAYER_SLAVE_ARGS)
+        return args
 
     @staticmethod
     def isValidPlayerPath(path):
@@ -270,9 +274,7 @@ class MplayerPlayer(BasePlayer):
                     filePath = None
                 else:
                     call.extend([filePath])
-            if args:
-                call.extend(args)
-            call.extend(playerController.getStartupArgs(playerPath))
+            call.extend(playerController.getStartupArgs(playerPath, args))
             # At least mpv may output escape sequences which result in syncplay
             # trying to parse something like
             # "\x1b[?1l\x1b>ANS_filename=blah.mkv". Work around this by

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -22,8 +22,11 @@ class MpvPlayer(MplayerPlayer):
             return OldMpvPlayer(client, MpvPlayer.getExpandedPath(playerPath), filePath, args)
 
     @staticmethod
-    def getStartupArgs(path):
-        args = constants.MPV_SLAVE_ARGS
+    def getStartupArgs(path, userArgs):
+        args = constants.MPV_ARGS
+        if userArgs:
+            args.extend(userArgs)
+        args.extend(constants.MPV_SLAVE_ARGS)
         if constants.MPV_NEW_VERSION:
             args.extend(constants.MPV_SLAVE_ARGS_NEW)
         return args


### PR DESCRIPTION
This allows the per-player user arguments to overwrite
Syncplay's style defaults in mpv.

Be careful that, if you turn off force-window and idle, you have to
supply Syncplay with the filename before opening the video window.