### PR TITLE
Add player command latency compensation

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -258,6 +258,10 @@ class SyncplayClient(object):
 
     def _serverUnpaused(self, setBy):
         hideFromOSD = not constants.SHOW_SAME_ROOM_OSD
+        # In high-player-latency situations we might report our state back to
+        # the server before any player status is accepted as fresh. Override
+        # the locally-stored playback state.
+        self._playerPaused = False
         self._playerCommand(self._player.setPaused, False)
         madeChangeOnPlayer = True
         self.ui.showMessage(getMessage("unpause-notification").format(setBy), hideFromOSD)
@@ -265,6 +269,7 @@ class SyncplayClient(object):
 
     def _serverPaused(self, setBy):
         hideFromOSD = not constants.SHOW_SAME_ROOM_OSD
+        self._playerPaused = True
         if constants.SYNC_ON_PAUSE and self.getUsername() <> setBy:
             self.setPosition(self.getGlobalPosition())
         self._playerCommand(self._player.setPaused, True)

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -178,7 +178,7 @@ class SyncplayClient(object):
     def updatePlayerStatus(self, paused, position, cookie=None):
         # Ignore status report if the cookie is stale
         if cookie is not None and \
-                cookie < constants.PLAYER_COMMAND_DELAY + self._lastPlayerCommand:
+                cookie < self._lastPlayerCommand + self._config['playerCommandDelay']:
             return
 
         position -= self.getUserOffset()

--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -49,6 +49,7 @@ SERVER_STATE_INTERVAL = 1
 WARNING_OSD_MESSAGES_LOOP_INTERVAL = 1
 AUTOPLAY_DELAY = 3.0
 SYNC_ON_PAUSE = True  # Client seek to global position - subtitles may disappear on some media players
+DEFAULT_PLAYER_COMMAND_DELAY = 0.05
 
 # Options for the File Switch feature:
 FOLDER_SEARCH_TIMEOUT = 60.0 # Secs - How long to wait until searches in folder to update cache are aborted (may be longer than this if hard drive needs to spin up)

--- a/syncplay/messages.py
+++ b/syncplay/messages.py
@@ -194,6 +194,9 @@ en = {
       "forceguiprompt-label" : "Don't always show the Syncplay configuration window", # (Inverted)
       "nostore-label" : "Don't store this configuration", # (Inverted)
       "showosd-label" : "Enable OSD Messages",
+      "playercommanddelay-title" : "Player latency compensation",
+      "playercommanddelay-label" : "Seconds to ignore player status after commands",
+      "playercommanddelay-tooltip" : "Larger values are less likely to spuriously (un)pause but tend to sync less accurately.",
 
       "showosdwarnings-label" : "Include warnings (e.g. when files are different, users not ready)",
       "showsameroomosd-label" : "Include events in your room",

--- a/syncplay/players/basePlayer.py
+++ b/syncplay/players/basePlayer.py
@@ -6,7 +6,7 @@ class BasePlayer(object):
     execute updatePlayerStatus(paused, position) on client
     Given the arguments: boolean paused and float position in seconds 
     '''
-    def askForStatus(self):
+    def askForStatus(self, cookie=None):
         raise NotImplementedError()
 
     '''

--- a/syncplay/players/mpc.py
+++ b/syncplay/players/mpc.py
@@ -420,20 +420,22 @@ class MPCHCAPIPlayer(BasePlayer):
         return self._mpcApi.lastFilePosition
     
     @retry(MpcHcApi.PlayerNotReadyException, constants.MPC_MAX_RETRIES, constants.MPC_RETRY_WAIT_TIME, 1)
-    def askForStatus(self):
+    def askForStatus(self, cookie=None):
         if self._mpcApi.filePlaying and self.__preventAsking.wait(0) and self.__fileUpdate.acquire(0):
             self.__fileUpdate.release()
             position = self.__getPosition()
             paused = self._mpcApi.isPaused()
             position = float(position)
             if self.__preventAsking.wait(0) and self.__fileUpdate.acquire(0):
-                self.__client.updatePlayerStatus(paused, position)
+                self.__client.updatePlayerStatus(paused, position, cookie=cookie)
                 self.__fileUpdate.release()
             return
-        self.__echoGlobalStatus()
+        self.__echoGlobalStatus(cookie)
             
-    def __echoGlobalStatus(self):
-        self.__client.updatePlayerStatus(self.__client.getGlobalPaused(), self.__client.getGlobalPosition())
+    def __echoGlobalStatus(self, cookie):
+        self.__client.updatePlayerStatus(self.__client.getGlobalPaused(),
+                                         self.__client.getGlobalPosition(),
+                                         cookie=cookie)
 
     def __forcePause(self):
         for _ in xrange(constants.MPC_MAX_RETRIES):

--- a/syncplay/players/mplayer.py
+++ b/syncplay/players/mplayer.py
@@ -72,14 +72,14 @@ class MplayerPlayer(BasePlayer):
         self.reactor.callLater(0, self._client.initPlayer, self)
         self._onFileUpdate()
 
-    def askForStatus(self):
+    def askForStatus(self, cookie=None):
         self._positionAsk.clear()
         self._pausedAsk.clear()
         self._getPaused()
         self._getPosition()
         self._positionAsk.wait()
         self._pausedAsk.wait()
-        self._client.updatePlayerStatus(self._paused, self._position)
+        self._client.updatePlayerStatus(self._paused, self._position, cookie=cookie)
 
     def _setProperty(self, property_, value):
         self._listener.sendLine("set_property {} {}".format(property_, value))

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -154,14 +154,16 @@ class NewMpvPlayer(OldMpvPlayer):
         else:
             self._paused = self._client.getGlobalPaused()
 
-    def askForStatus(self):
+    def askForStatus(self, cookie=None):
         self._positionAsk.clear()
         self._pausedAsk.clear()
         self._getPaused()
         self._getPosition()
         self._positionAsk.wait(constants.MPV_LOCK_WAIT_TIME)
         self._pausedAsk.wait(constants.MPV_LOCK_WAIT_TIME)
-        self._client.updatePlayerStatus(self._paused if self.fileLoaded else self._client.getGlobalPaused(), self.getCalculatedPosition())
+        self._client.updatePlayerStatus(self._paused if self.fileLoaded else self._client.getGlobalPaused(),
+                                        self.getCalculatedPosition(),
+                                        cookie=cookie)
 
     def _preparePlayer(self):
         if self.delayedFilePath:

--- a/syncplay/players/vlc.py
+++ b/syncplay/players/vlc.py
@@ -84,16 +84,20 @@ class VlcPlayer(BasePlayer):
         self.setPaused(self._client.getGlobalPaused())
         self.setPosition(self._client.getGlobalPosition())
 
-    def askForStatus(self):
+    def askForStatus(self, cookie=None):
         self._filechanged = False
         self._positionAsk.clear()
         self._pausedAsk.clear()
         self._listener.sendLine(".")
         if self._filename and not self._filechanged:
             self._positionAsk.wait(constants.PLAYER_ASK_DELAY)
-            self._client.updatePlayerStatus(self._paused, self.getCalculatedPosition())
+            self._client.updatePlayerStatus(self._paused,
+                                            self.getCalculatedPosition(),
+                                            cookie=cookie)
         else:
-            self._client.updatePlayerStatus(self._client.getGlobalPaused(), self._client.getGlobalPosition())
+            self._client.updatePlayerStatus(self._client.getGlobalPaused(),
+                                            self._client.getGlobalPosition(),
+                                            cookie=cookie)
 
     def getCalculatedPosition(self):
         if self._lastVLCPositionUpdate is None:

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -63,7 +63,8 @@ class ConfigurationGetter(object):
                         "showSameRoomOSD" : True,
                         "showNonControllerOSD" : False,
                         "showContactInfo" : True,
-                        "showDurationNotification" : True
+                        "showDurationNotification" : True,
+                        "playerCommandDelay": constants.DEFAULT_PLAYER_COMMAND_DELAY
                         }
 
         self._defaultConfig = self._config.copy()
@@ -117,11 +118,21 @@ class ConfigurationGetter(object):
             "rewindThreshold",
             "fastforwardThreshold",
             "autoplayMinUsers",
+            "playerCommandDelay",
         ]
 
         self._iniStructure = {
                         "server_data": ["host", "port", "password"],
-                        "client_settings": ["name", "room", "playerPath", "perPlayerArguments", "slowdownThreshold", "rewindThreshold", "fastforwardThreshold", "slowOnDesync", "rewindOnDesync", "fastforwardOnDesync", "dontSlowDownWithMe", "forceGuiPrompt", "filenamePrivacyMode", "filesizePrivacyMode", "unpauseAction", "pauseOnLeave", "readyAtStart", "autoplayMinUsers", "autoplayInitialState", "mediaSearchDirectories"],
+                        "client_settings": ["name", "room", "playerPath",
+                            "perPlayerArguments", "slowdownThreshold",
+                            "rewindThreshold", "fastforwardThreshold",
+                            "slowOnDesync", "rewindOnDesync",
+                            "fastforwardOnDesync", "dontSlowDownWithMe",
+                            "forceGuiPrompt", "filenamePrivacyMode",
+                            "filesizePrivacyMode", "unpauseAction",
+                            "pauseOnLeave", "readyAtStart", "autoplayMinUsers",
+                            "autoplayInitialState", "mediaSearchDirectories",
+                            "playerCommandDelay"],
                         "gui": ["showOSD", "showOSDWarnings", "showSlowdownOSD", "showDifferentRoomOSD", "showSameRoomOSD", "showNonControllerOSD", "showDurationNotification"],
                         "general": ["language", "checkForUpdatesAutomatically", "lastCheckedForUpdates"]
                         }

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -389,6 +389,8 @@ class ConfigDialog(QtGui.QDialog):
                 self.config[radioName] = radioValue
         elif isinstance(widget, QLineEdit):
             self.config[valueName] = widget.text()
+        elif isinstance(widget, QDoubleSpinBox):
+            self.config[valueName] = widget.value()
 
     def connectChildren(self, widget):
         widgetName = str(widget.objectName())
@@ -687,7 +689,7 @@ class ConfigDialog(QtGui.QDialog):
         self.commandDelaySpinbox = QDoubleSpinBox()
         self.commandDelaySpinbox.setObjectName("playerCommandDelay")
         self.commandDelaySpinbox.setMaximum(10)
-        self.commandDelaySpinbox.setSingleStep(.01)
+        self.commandDelaySpinbox.setSingleStep(.1)
 
         self.desyncSettingsLayout = QtGui.QGridLayout()
         self.desyncSettingsLayout.setSpacing(2)

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -365,6 +365,8 @@ class ConfigDialog(QtGui.QDialog):
                 widget.setChecked(True)
         elif isinstance(widget, QLineEdit):
             widget.setText(self.config[valueName])
+        elif isinstance(widget, QDoubleSpinBox):
+            widget.setValue(self.config[valueName])
 
     def saveValues(self, widget):
         valueName = str(widget.objectName())
@@ -682,6 +684,10 @@ class ConfigDialog(QtGui.QDialog):
         self.rewindCheckbox.setObjectName("rewindOnDesync")
         self.fastforwardCheckbox = QCheckBox(getMessage("fastforwardondesync-label"))
         self.fastforwardCheckbox.setObjectName("fastforwardOnDesync")
+        self.commandDelaySpinbox = QDoubleSpinBox()
+        self.commandDelaySpinbox.setObjectName("playerCommandDelay")
+        self.commandDelaySpinbox.setMaximum(10)
+        self.commandDelaySpinbox.setSingleStep(.01)
 
         self.desyncSettingsLayout = QtGui.QGridLayout()
         self.desyncSettingsLayout.setSpacing(2)
@@ -710,10 +716,17 @@ class ConfigDialog(QtGui.QDialog):
         self.othersyncSettingsLayout.setAlignment(Qt.AlignLeft)
         self.othersyncSettingsLayout.addWidget(self.fastforwardCheckbox, 3, 0,1,2, Qt.AlignLeft)
 
+        self.playerLatencyGroup = QtGui.QGroupBox(getMessage("playercommanddelay-title"))
+        self.playerLatencyLayout = QtGui.QHBoxLayout()
+        self.playerLatencyGroup.setLayout(self.playerLatencyLayout)
+        self.playerLatencyLayout.addWidget(self.commandDelaySpinbox)
+        self.playerLatencyLayout.addWidget(QLabel(getMessage("playercommanddelay-label")))
+
         self.othersyncSettingsGroup.setLayout(self.othersyncSettingsLayout)
         self.othersyncSettingsGroup.setMaximumHeight(self.othersyncSettingsGroup.minimumSizeHint().height())
         self.syncSettingsLayout.addWidget(self.othersyncSettingsGroup)
         self.syncSettingsLayout.addWidget(self.desyncSettingsGroup)
+        self.syncSettingsLayout.addWidget(self.playerLatencyGroup)
         self.syncSettingsFrame.setLayout(self.syncSettingsLayout)
         self.desyncSettingsGroup.setMaximumHeight(self.desyncSettingsGroup.minimumSizeHint().height())
         self.syncSettingsLayout.setAlignment(Qt.AlignTop)


### PR DESCRIPTION
Somewhat experimental fix for #73. Worked very well with XBMC/Kodi (coming soon to a PR near you), didn't seem to have any ill effect on VLC or MPC, the two existing players I tested with.

`playerCommandDelay` should generally be set to an amount of time longer than the expected largest delay between sending a play/pause/seek command and having that command reflected in the status reported back to the client. Some kind of autoconfiguration (or just a warning if "fighting" is observed) would be nice, but this at least provides a configuration option for user adjustment.

With appropriate configuration, I suspect this fixes issues with madVR when "delay playback start until render queue is full" as well, as reported in #52.