### PR TITLE
bugfix: display the menu bar in OS X

### DIFF
--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -875,7 +875,8 @@ class MainWindow(QtGui.QMainWindow):
         window.updateAction.triggered.connect(self.userCheckForUpdates)
 
         window.menuBar.addMenu(window.helpMenu)
-        window.mainLayout.setMenuBar(window.menuBar)
+        if not sys.platform.startswith('darwin'):
+            window.mainLayout.setMenuBar(window.menuBar)
 
     def addMainFrame(self, window):
         window.mainFrame = QtGui.QFrame()


### PR DESCRIPTION
A picture (or screenshot) says more than a thousand words:

![screen shot 2015-12-19 at 19 41 11](https://cloud.githubusercontent.com/assets/1809170/11914767/7afad116-a688-11e5-8d52-c7d7df248be4.png)

Now let's work on the other issues @Et0h [mentioned](https://github.com/Syncplay/syncplay/issues/81#issuecomment-162468488) in #81. 