### PR TITLE
Support mpv without length property

### DIFF
--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -157,7 +157,7 @@ USERLIST_GUI_FILENAME_COLUMN = 3
 MPLAYER_SLAVE_ARGS = ['-slave', '--hr-seek=always', '-nomsgcolor', '-msglevel', 'all=1:global=4:cplayer=4', '-af-add', 'scaletempo']
 MPV_ARGS = ['--force-window', '--idle', '--hr-seek=always', '--keep-open']
 MPV_SLAVE_ARGS = ['--msg-level=all=error,cplayer=info,term-msg=info', '--input-terminal=no', '--input-file=/dev/stdin']
-MPV_SLAVE_ARGS_NEW = ['--term-playing-msg=<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=length}\nANS_path=${path}\n</SyncplayUpdateFile>', '--terminal=yes']
+MPV_SLAVE_ARGS_NEW = ['--term-playing-msg=<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=length:${=duration:0}}\nANS_path=${path}\n</SyncplayUpdateFile>', '--terminal=yes']
 MPV_NEW_VERSION = False
 VLC_SLAVE_ARGS = ['--extraintf=luaintf', '--lua-intf=syncplay', '--no-quiet', '--no-input-fast-seek',
                   '--play-and-pause', '--start-time=0']

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -120,9 +120,11 @@ class NewMpvPlayer(OldMpvPlayer):
             self.lastMPVPositionUpdate = time.time()
 
     def _getProperty(self, property_):
-        floatProperties = ['length','time-pos']
+        floatProperties = ['time-pos']
         if property_ in floatProperties:
             propertyID = u"={}".format(property_)
+        elif property_ == 'length':
+            propertyID = u'=length:${=duration:0}'
         else:
             propertyID = property_
         self._listener.sendLine(u"print_text ""ANS_{}=${{{}}}""".format(property_, propertyID))

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -7,7 +7,7 @@ from syncplay.utils import isURL
 import os, sys, time
 
 class MpvPlayer(MplayerPlayer):
-    RE_VERSION = re.compile('.*mpv (\d)\.(\d)\.\d.*')
+    RE_VERSION = re.compile('.*mpv (\d+)\.(\d+)\.\d+.*')
     osdMessageSeparator = "\\n"
 
     @staticmethod


### PR DESCRIPTION
The 'length' property was deprecated since then and will be gone
with 0.23.0 and is already gone in git master, so Syncplay is
broken with it.