### PR TITLE
Prevents App Nap on macOS 10.9+

### DIFF
--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -407,6 +407,9 @@ class ConfigurationGetter(object):
                 if QCoreApplication.instance() is None:
                     self.app = QtGui.QApplication(sys.argv)
                 qt4reactor.install()
+                if sys.platform.startswith('darwin'):
+                    import appnope
+                    appnope.nope()
             except ImportError:
                 print getMessage("unable-import-gui-error")
                 self._config['noGui'] = True


### PR DESCRIPTION
Solves #116 and #60 (finally). 
Adds a new dependency: `appnope` [(GitHub)](https://github.com/minrk/appnope), required only on macOS. It is available on pip. If merged, I guess the installation instructions have to be updated accordingly.

(Note: please be patient if I did something horribly wrong since this is my first pull request.)