### PR TITLE
buildPy2exe: Find installed NSIS through registry

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -5,7 +5,7 @@
 
 ) If you get the error "ImportError: No module named zope.interface" then add an empty __init__.py file to the PYTHONDIR/Lib/site-packages/zope directory
 
-2) It is expected that you will have NSIS 3  NSIS from http://nsis.sourceforge.net installed to: C:\Program Files (x86)\NSIS\
+2) It is expected that you will have NSIS 3 NSIS from http://nsis.sourceforge.net installed.
 
 '''
 
@@ -31,8 +31,24 @@ if missingStrings is not None and missingStrings is not "":
     import warnings
     warnings.warn("MISSING/UNUSED STRINGS DETECTED:\n{}".format(missingStrings))
 
-p = "C:\\Program Files (x86)\\NSIS\\makensis.exe" #TODO: how to move that into proper place, huh
-NSIS_COMPILE = p if os.path.isfile(p) else "makensis.exe"
+def get_nsis_path():
+    bin_name = "makensis.exe"
+    try:
+        from winreg import HKEY_LOCAL_MACHINE as HKLM
+        from winreg import KEY_READ, KEY_WOW64_32KEY, OpenKey, QueryValueEx
+    except ImportError:
+        return bin_name
+
+    try:
+        nsisreg = OpenKey(HKLM, "Software\\NSIS", 0, KEY_READ | KEY_WOW64_32KEY)
+        if QueryValueEx(nsisreg, "VersionMajor")[0] >= 3:
+            return "{}\\{}".format(QueryValueEx(nsisreg, "")[0], bin_name)
+        else:
+            raise Exception("You must install NSIS 3 or later.")
+    except WindowsError:
+        return bin_name
+NSIS_COMPILE = get_nsis_path()
+
 OUT_DIR = "syncplay_v{}".format(syncplay.version)
 SETUP_SCRIPT_PATH = "syncplay_setup.nsi"
 NSIS_SCRIPT_TEMPLATE = r"""


### PR DESCRIPTION
Require NSIS >=3 for unicode support