### PR TITLE
Supporting for Italian translation.

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -57,6 +57,7 @@ NSIS_SCRIPT_TEMPLATE = r"""
   LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Polish.nlf"
   LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Russian.nlf"
   LoadLanguageFile "$${NSISDIR}\Contrib\Language files\German.nlf"
+  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Italian.nlf"
 
   Unicode true
 
@@ -83,6 +84,11 @@ NSIS_SCRIPT_TEMPLATE = r"""
   VIAddVersionKey /LANG=$${LANG_RUSSIAN} "FileVersion" "$version.0"
   VIAddVersionKey /LANG=$${LANG_RUSSIAN} "LegalCopyright" "Syncplay"
   VIAddVersionKey /LANG=$${LANG_RUSSIAN} "FileDescription" "Syncplay"
+  
+  VIAddVersionKey /LANG=$${LANG_ITALIAN} "ProductName" "Syncplay"
+  VIAddVersionKey /LANG=$${LANG_ITALIAN} "FileVersion" "$version.0"
+  VIAddVersionKey /LANG=$${LANG_ITALIAN} "LegalCopyright" "Syncplay"
+  VIAddVersionKey /LANG=$${LANG_ITALIAN} "FileDescription" "Syncplay"
 
   LangString ^SyncplayLanguage $${LANG_ENGLISH} "en"
   LangString ^Associate $${LANG_ENGLISH} "Associate Syncplay with multimedia files."
@@ -126,6 +132,17 @@ NSIS_SCRIPT_TEMPLATE = r"""
   LangString ^QuickLaunchBar $${LANG_GERMAN} "Schnellstartleiste"
   LangString ^AutomaticUpdates $${LANG_GERMAN} "Automatisch nach Updates suchen";
   LangString ^UninstConfig $${LANG_GERMAN} "Konfigurationsdatei löschen."
+  
+  LangString ^SyncplayLanguage $${LANG_ITALIAN} "it"
+  LangString ^Associate $${LANG_ITALIAN} "Associa Syncplay con i file multimediali."
+  LangString ^VLC $${LANG_ITALIAN} "Installa l'interfaccia di Syncplay per VLC 2+"
+  LangString ^BrowseVLCBtn $${LANG_ITALIAN} "Cartella di VLC"
+  LangString ^Shortcut $${LANG_ITALIAN} "Crea i collegamenti nei percorsi seguenti:"
+  LangString ^StartMenu $${LANG_ITALIAN} "Menu Start"
+  LangString ^Desktop $${LANG_ITALIAN} "Desktop"
+  LangString ^QuickLaunchBar $${LANG_ITALIAN} "Barra di avvio rapido"
+  LangString ^AutomaticUpdates $${LANG_ITALIAN} "Controllo automatico degli aggiornamenti"
+  LangString ^UninstConfig $${LANG_ITALIAN} "Cancella i file di configurazione."
 
   ; Remove text to save space
   LangString ^ClickInstall $${LANG_GERMAN} " "
@@ -233,6 +250,8 @@ NSIS_SCRIPT_TEMPLATE = r"""
     Push Русский
     Push $${LANG_GERMAN}
     Push Deutsch
+	Push $${LANG_ITALIAN}
+    Push Italiano
     Push A ; A means auto count languages
     LangDLL::LangDialog "Language Selection" "Please select the language of Syncplay and the installer"
     Pop $$LANGUAGE

--- a/syncplay/messages.py
+++ b/syncplay/messages.py
@@ -4,11 +4,13 @@ from syncplay import constants
 import messages_en
 import messages_ru
 import messages_de
+import messages_it
 
 messages = {
            "en": messages_en.en,
            "ru": messages_ru.ru,
            "de": messages_de.de,
+           "it": messages_it.it,
            "CURRENT": None
            }
 

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -245,6 +245,7 @@ de = {
     "chat-top-option": u"Top", # TODO: Translate
     "chat-middle-option": u"Middle", # TODO: Translate
     "chat-bottom-option": u"Bottom", # TODO: Translate
+    "chatoutputheader-label" : u"Chat message output", # TODO: Translate
     "chatoutputfont-label": u"Chat output font",  # TODO: Translate
     "chatoutputenabled-label": u"Enable chat output in media player (mpv only for now)",  # TODO: Translate
     "chatoutputposition-label": u"Output mode",  # TODO: Translate
@@ -305,7 +306,7 @@ de = {
     "help-menu-label" : u"&Hilfe",
     "userguide-menu-label" : u"&Benutzerhandbuch öffnen",
     "update-menu-label" : u"auf &Aktualisierung prüfen",
-    
+
     #About dialog - TODO: Translate
     "about-menu-label": u"&About Syncplay",
     "about-dialog-title": u"About Syncplay",

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -127,7 +127,7 @@ en = {
     "empty-value-config-error" : "{} can't be empty", # Config option
 
     "not-json-error" : "Not a json encoded string\n",
-    "hello-arguments-error" : "Not enough Hello arguments\n",
+    "hello-arguments-error" : "Not enough Hello arguments\n", # DO NOT TRANSLATE
     "version-mismatch-error" : "Mismatch between versions of client and server\n",
     "vlc-failed-connection": "Failed to connect to VLC. If you have not installed syncplay.lua and are using the latest verion of VLC then please refer to http://syncplay.pl/LUA/ for instructions.",
     "vlc-failed-noscript": "VLC has reported that the syncplay.lua interface script has not been installed. Please refer to http://syncplay.pl/LUA/ for instructions.",
@@ -447,7 +447,7 @@ en = {
     "client-drop-server-error" : u"Client drop: {} -- {}",  # host, error
     "password-required-server-error" : "Password required",
     "wrong-password-server-error" : "Wrong password supplied",
-    "hello-server-error" : "Not enough Hello arguments",
+    "hello-server-error" : "Not enough Hello arguments", #DO NOT TRANSLATE
 
     # Playlists
     "playlist-selection-changed-notification" :  u"{} changed the playlist selection", # Username

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -137,7 +137,7 @@ en = {
     "feature-chat" : u"chat", # used for not-supported-by-server-error
     "feature-readiness" : u"readiness", # used for not-supported-by-server-error
     "feature-managedRooms" : u"managed rooms", # used for not-supported-by-server-error
-    
+
     "not-supported-by-server-error" : u"The {} feature is not supported by this server..", #feature
     "shared-playlists-not-supported-by-server-error" : "The shared playlists feature may not be supported by the server. To ensure that it works correctly requires a server running Syncplay  {}+, but the server is running Syncplay {}.", #minVersion, serverVersion
     "shared-playlists-disabled-by-server-error" : "The shared playlist feature has been disabled in the server configuration. To use this feature you will need to connect to a different server.",
@@ -239,7 +239,7 @@ en = {
     "unpause-ifminusersready-option" : u"Unpause if already ready or if all others ready and min users ready",
     "unpause-always" : u"Always unpause",
     "syncplay-trusteddomains-title": u"Trusted domains (for streaming services and hosted content)",
-    
+
     "chat-title" : u"Chat message input",
     "chatinputenabled-label" : u"Enable chat input via mpv",
     "chatdirectinput-label" : u"Allow instant chat input (bypass having to press enter key to chat)",
@@ -250,6 +250,7 @@ en = {
     "chat-top-option" : u"Top",
     "chat-middle-option" : u"Middle",
     "chat-bottom-option" : u"Bottom",
+    "chatoutputheader-label" : u"Chat message output",
     "chatoutputfont-label": u"Chat output font",
     "chatoutputenabled-label": u"Enable chat output in media player (mpv only for now)",
     "chatoutputposition-label": u"Output mode",
@@ -310,7 +311,7 @@ en = {
     "help-menu-label" : "&Help",
     "userguide-menu-label" : "Open user &guide",
     "update-menu-label" : "Check for &update",
-    
+
     #About dialog
     "about-menu-label": u"&About Syncplay",
     "about-dialog-title": u"About Syncplay",

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -17,10 +17,10 @@ it = {
     "connected-successful-notification" : u"Connessione al server effettuata con successo",
     "retrying-notification" : u"%s, Nuovo tentativo in %d secondi...",  # Seconds
 
-    "rewind-notification" : u"Riavvolgendo a causa della differenza temporale con {}",  # User
+    "rewind-notification" : u"Riavvolgo a causa della differenza temporale con {}",  # User
     "fastforward-notification" : u"Avanzamento rapido a causa della differenza temporale con {}",  # User
-    "slowdown-notification" : u"Rallentando a causa della differenza temporale con {}",  # User
-    "revert-notification" : u"Ritornando alla velocità di riproduzione normale",
+    "slowdown-notification" : u"Rallento a causa della differenza temporale con {}",  # User
+    "revert-notification" : u"Velocità di riproduzione normale ripristinata",
 
     "pause-notification" : u"{} ha messo in pausa",  # User
     "unpause-notification" : u"{} ha ripreso la riproduzione",  # User
@@ -49,7 +49,7 @@ it = {
     "created-controlled-room-notification" : u"Stanza gestita '{}' creata con password '{}'. Per favore salva queste informazioni per una consultazione futura!", # RoomName, operatorPassword
 
     "file-different-notification" : u"Il file che stai riproducendo sembra essere diverso da quello di {}",  # User
-    "file-differences-notification" : u"Il tuo file possiede le seguenti differenze: {}", # Differences
+    "file-differences-notification" : u"Il tuo file mostra le seguenti differenze: {}", # Differences
     "room-file-differences" : u"Differenze nel tuo file: {}", # File differences (filename, size, and/or duration)
     "file-difference-filename" : u"nome",
     "file-difference-filesize" : u"dimensione",
@@ -68,9 +68,9 @@ it = {
 
     "update-check-failed-notification" : u"Controllo automatico degli aggiornamenti di Syncplay {} fallito. Vuoi visitare http://syncplay.pl/ per verificare manualmente la presenza di aggiornamenti?", #Syncplay version
     "syncplay-uptodate-notification" : u"Syncplay è aggiornato",
-    "syncplay-updateavailable-notification" : u"Nuova versione di Syncplay disponibile. Vuoi visitare la pagina delle release?",
+    "syncplay-updateavailable-notification" : u"Una nuova versione di Syncplay è disponibile. Vuoi visitare la pagina delle release?",
 
-    "mplayer-file-required-notification" : u"Utilizzare Syncplay con mplayer richiede la selezione del file all'avvio",
+    "mplayer-file-required-notification" : u"Utilizzare Syncplay con mplayer di selezionare il file all'avvio",
     "mplayer-file-required-notification/example" : u"Esempio di utilizzo: syncplay [opzioni] [url|percorso/]nomefile",
     "mplayer2-required" : u"Syncplay non è compatibile con MPlayer 1.x, per favore utilizza mplayer2 or mpv",
 
@@ -81,7 +81,7 @@ it = {
     "commandlist-notification/undo" : u"\tu - annulla l'ultima ricerca",
     "commandlist-notification/pause" : u"\tp - attiva o disattiva la pausa",
     "commandlist-notification/seek" : u"\t[s][+-]tempo - salta all'istante di tempo dato, se + o - non è specificato si considera il tempo assoluto in secondi o min:sec",
-    "commandlist-notification/help" : u"\th - questo help",
+    "commandlist-notification/help" : u"\th - mostra questo help",
     "commandlist-notification/toggle" : u"\tt - attiva o disattiva lo stato 'Pronto'",
     "commandlist-notification/create" : u"\tc [nome] - crea una stanza gestita usando il nome della stanza attuale",
     "commandlist-notification/auth" : u"\ta [password] - autentica come gestore della stanza, utilizzando la password del gestore",
@@ -89,7 +89,7 @@ it = {
     "syncplay-version-notification" : u"Versione di Syncplay: {}",  # syncplay.version
     "more-info-notification" : u"Maggiori informazioni a: {}",  # projectURL
 
-    "gui-data-cleared-notification" : u"Syncplay ha resettato i dati, usati dalla GUI, relativi ai percorsi ed allo stato delle finestre.",
+    "gui-data-cleared-notification" : u"Syncplay ha resettato i dati dell'interfaccia relativi ai percorsi e allo stato delle finestre.",
     "language-changed-msgbox-label" : u"La lingua sarà cambiata quando avvierai Syncplay.",
     "promptforupdate-label" : u"Ti piacerebbe che, di tanto in tanto, Syncplay controllasse automaticamente la presenza di aggiornamenti?",
 
@@ -106,25 +106,25 @@ it = {
     "missing-arguments-error" : u"Alcuni argomenti obbligatori non sono stati trovati. Fai riferimento a --help",
     "server-timeout-error" : u"Connessione col server scaduta",
     "mpc-slave-error" : u"Non è possibile avviare MPC in modalità slave!",
-    "mpc-version-insufficient-error" : u"Versione di MPC non sufficiente, per favore usa `mpc-hc` >= `{}`",
-    "mpc-be-version-insufficient-error" : u"Versione di MPC non sufficiente, per favore usa `mpc-be` >= `{}`",
+    "mpc-version-insufficient-error" : u"La tua versione di MPC è troppo vecchia, per favore usa `mpc-hc` >= `{}`",
+    "mpc-be-version-insufficient-error" : u"La tua versione di MPC è troppo vecchia, per favore usa `mpc-be` >= `{}`",
     "mpv-version-error" : u"Syncplay non è compatibile con questa versione di mpv. Per favore usa un'altra versione di mpv (es. Git HEAD).",
     "player-file-open-error" : u"Il player non è riuscito ad aprire il file",
     "player-path-error" : u"Il path del player non è configurato correttamente. I player supportati sono: mpv, VLC, MPC-HC, MPC-BE e mplayer2",
-    "hostname-empty-error" : u"Hostname non può essere vuoto",
-    "empty-error" : u"{} non può esssere vuoto",  # Configuration
+    "hostname-empty-error" : u"Il campo hostname non può essere vuoto",
+    "empty-error" : u"Il campo {} non può esssere vuoto",  # Configuration
     "media-player-error": u"Errore media player: \"{}\"",  # Error line
-    "unable-import-gui-error": u"Non è possibile importare le librerie GUI. Hai bisogno di PySide per poter utilizzare la GUI.",
+    "unable-import-gui-error": u"Non è possibile importare le librerie di interfaccia grafica. Hai bisogno di PySide per poter utilizzare l'interfaccia grafica.",
 
     "arguments-missing-error" : u"Alcuni argomenti obbligatori non sono stati trovati. Fai riferimento a --help",
 
     "unable-to-start-client-error" : u"Impossibile avviare il client",
 
-    "player-path-config-error": u"Il path del player non è configurato correttamente. I player supportati sono: mpv, VLC, MPC-HC, MPC-BE e mplayer2.",
+    "player-path-config-error": u"Il percorso del player non è configurato correttamente. I player supportati sono: mpv, VLC, MPC-HC, MPC-BE e mplayer2.",
     "no-file-path-config-error" :u"Deve essere selezionato un file prima di avviare il player",
-    "no-hostname-config-error": u"Hostname non può essere vuoto",
+    "no-hostname-config-error": u"Il campo hostname non può essere vuoto",
     "invalid-port-config-error" : u"La porta deve essere valida",
-    "empty-value-config-error" : u"{} non può essere vuoto", # Config option
+    "empty-value-config-error" : u"Il campo {} non può essere vuoto", # Config option
 
     "not-json-error" : u"Non è una stringa con codifica JSON\n",
     "hello-arguments-error" : u"Argomenti Hello non sufficienti\n",
@@ -140,37 +140,37 @@ it = {
     "feature-managedRooms" : u"stanze gestite", # used for not-supported-by-server-error
 
     "not-supported-by-server-error" : u"La feature {} non è supportata da questo server..", #feature
-    "shared-playlists-not-supported-by-server-error" : u"La feature playlist condivise potrebbe non essere supportata dal server. Si necessita di un server avente Syncplay {}+ per assicurarsi che essa funzioni correttamente, tuttavia il server sta utilizzando Syncplay {}.", #minVersion, serverVersion
-    "shared-playlists-disabled-by-server-error" : u"La feature playlist condivise è stata disabilitata nella configurazione del server. Per utilizzarla, dovrai collegarti ad un altro server.",
+    "shared-playlists-not-supported-by-server-error" : u"Le playlist condivise potrebbero non essere supportata dal server. È necessario un server con Syncplay {}+ per assicurarsi che funzionino correttamente, tuttavia il server sta utilizzando Syncplay {}.", #minVersion, serverVersion
+    "shared-playlists-disabled-by-server-error" : u"Le playlist condivise sono state disabilitate nella configurazione del server. Per utilizzarle, dovrai collegarti a un altro server.",
 
     "invalid-seek-value" : u"Valore di ricerca non valido",
     "invalid-offset-value" : u"Valore di offset non valido",
 
-    "switch-file-not-found-error" : u"Impossibile passare al file '{0}'. Syncplay analizza le cartelle multimediali specificate.", # File not found
-    "folder-search-timeout-error" : u"La ricerca nelle cartelle multimediali è stata interrotta siccome l'analisi di '{}' sta impiegando troppo tempo. Ciò accade se si aggiunge una cartella con troppe sottocartelle nella lista di ricerca. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali nella barra dei menù e rimuovi questa cartella o sostituiscila con una sottocartella appropriata. Se la cartella è idonea, è possibile riabilitarla selezionando File->Imposta cartelle multimediali e premendo 'OK'.", #Folder
-    "folder-search-first-file-timeout-error" : u"La ricerca dei media in '{}' è stata interrotta siccome l'accesso alla cartella sta impiegando troppo tempo. Ciò accade se essa è un disco di rete oppure se hai impostato il blocco della rotazione del disco rigido dopo un certo periodo di inattività. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali, quindi rimuovi la cartella oppure risolvi il problema (es. cambiando le impostazioni del risparmio energetico).", #Folder
-    "added-file-not-in-media-directory-error" : u"Hai selezionato un file in '{}'. Essa non è una cartella multimediale conosciuta. Puoi aggiungerla come cartella multimediale selezionando File->Imposta cartelle multimediali nella barra dei menù.", #Folder
-    "no-media-directories-error" : u"Nessuna cartella multimediale è stata configurata. Per permette il corretto funzionamento delle feature playlist condivise e selezione automatica dei file, naviga in File->Imposta cartelle multimediali e specifica dove Syncplay debba ricercare i file multimediali.",
-    "cannot-find-directory-error" : u"Impossibile trovare la cartella multimediale '{}'. Per aggiornare la lista delle cartelle multimediali seleziona File->Imposta cartelle multimediali dalla barra dei menù e specifica dove Syncplay debba ricercare i file multimediali.",
+    "switch-file-not-found-error" : u"Impossibile selezionare il file '{0}'. Syncplay osserva solo le cartelle multimediali specificate.", # File not found
+    "folder-search-timeout-error" : u"La ricerca nelle cartelle multimediali è stata interrotta perché l'analisi di '{}' sta impiegando troppo tempo. Ciò accade se si aggiunge nella lista di ricerca una cartella con troppe sottocartelle. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali nella barra dei menù e rimuovi questa cartella, o sostituiscila con una sottocartella appropriata. Se la cartella è idonea, è possibile riabilitarla selezionando File->Imposta cartelle multimediali e premendo 'OK'.", #Folder
+    "folder-search-first-file-timeout-error" : u"La ricerca dei media in '{}' è stata interrotta perché l'accesso alla cartella sta impiegando troppo tempo. Ciò accade se questa si trova in un disco di rete oppure se hai impostato il blocco della rotazione del disco rigido dopo un certo periodo di inattività. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali, quindi rimuovi la cartella oppure risolvi il problema (es. cambiando le impostazioni di risparmio energetico).", #Folder
+    "added-file-not-in-media-directory-error" : u"Hai selezionato un file in '{}', che non è impostata come cartella multimediale. Puoi aggiungerla come cartella multimediale selezionando File->Imposta cartelle multimediali nella barra dei menù.", #Folder
+    "no-media-directories-error" : u"Nessuna cartella multimediale è stata configurata. Per permettere il corretto funzionamento delle playlist condivise e la selezione automatica dei file, naviga in File->Imposta cartelle multimediali e specifica dove Syncplay deve ricercare i file multimediali.",
+    "cannot-find-directory-error" : u"Impossibile trovare la cartella multimediale '{}'. Per aggiornare la lista delle cartelle multimediali seleziona File->Imposta cartelle multimediali dalla barra dei menù e specifica dove Syncplay deve ricercare i file multimediali.",
 
-    "failed-to-load-server-list-error" : u"Impossibile caricare la lista dei server pubblici. Per favore, visita http://www.syncplay.pl/ col tuo browser.",
+    "failed-to-load-server-list-error" : u"Impossibile caricare la lista dei server pubblici. Per favore, visita http://www.syncplay.pl/ con il tuo browser.",
 
     # Client arguments
-    "argument-description" : u'Soluzione per sincronizzare la riproduzione di istanze di media player multiple attraverso la rete.',
+    "argument-description" : u'Programma per sincronizzare la riproduzione di media player multipli attraverso la rete.',
     "argument-epilog" : u'Se non è specificata alcuna opzione saranno utilizzati i valori _config',
-    "nogui-argument" : u'non mostrare la GUI',
+    "nogui-argument" : u'non mostrare l\'interfaccia grafica',
     "host-argument" : u'indirizzo del server',
     "name-argument" : u'username desiderato',
     "debug-argument" : u'modalità debug',
-    "force-gui-prompt-argument" : u'mostra il prompt di configurazione',
-    "no-store-argument" : u'non salva i valori in .syncplay',
+    "force-gui-prompt-argument" : u'mostra la finestra di configurazione',
+    "no-store-argument" : u'non salvare i valori in .syncplay',
     "room-argument" : u'stanza di default',
     "password-argument" : u'password del server',
     "player-path-argument" : u'percorso dell\'eseguibile del tuo player',
     "file-argument" : u'file da riprodurre',
-    "args-argument" : u'opzioni del player, se hai bisogno di passare opzioni che iniziano con - anteponile con un singolo \'--\'',
-    "clear-gui-data-argument" : u'resetta il percorso e i dati inerenti allo stato della GUI salvati come QSettings',
-    "language-argument" : u'lingua per i messaggi di Syncplay (de/en/ru)',
+    "args-argument" : u'opzioni del player, se hai bisogno di utilizzare opzioni che iniziano con - anteponi un singolo \'--\'',
+    "clear-gui-data-argument" : u'resetta il percorso e i dati impostati tramite interfaccia grafica e salvati come QSettings',
+    "language-argument" : u'lingua per i messaggi di Syncplay (de/en/ru/it)',
 
     "version-argument" : u'mostra la tua versione',
     "version-message" : u"Stai usando la versione di Syncplay {} ({})",
@@ -187,48 +187,48 @@ it = {
     "media-setting-title" : u"Impostazioni del media player",
     "executable-path-label" : u"Percorso del media player:",
     "media-path-label" : u"Percorso del video (opzionale):",
-    "player-arguments-label" : u"Argomenti del player (se necessari):",
+    "player-arguments-label" : u"Opzioni del player (se necessarie):",
     "browse-label" : u"Sfoglia",
     "update-server-list-label" : u"Aggiorna lista",
 
     "more-title" : u"Mostra altre impostazioni",
     "never-rewind-value" : u"Mai",
-    "seconds-suffix" : u" secs",
+    "seconds-suffix" : u" sec",
     "privacy-sendraw-option" : u"Invio semplice",
-    "privacy-sendhashed-option" : u"Invio criptato",
+    "privacy-sendhashed-option" : u"Invio cifrato",
     "privacy-dontsend-option" : u"Non inviare",
     "filename-privacy-label" : u"Nome del file:",
     "filesize-privacy-label" : u"Dimensione del file:",
     "checkforupdatesautomatically-label" : u"Controlla automaticamente gli aggiornamenti di Syncplay",
-    "slowondesync-label" : u"Rallenta in caso di desync minimo (non supportato su MPC-HC/BE)",
-    "rewindondesync-label" : u"Riavvolgi in caso di desync grave (consigliato)",
+    "slowondesync-label" : u"Rallenta in caso di sfasamento minimo (non supportato su MPC-HC/BE)",
+    "rewindondesync-label" : u"Riavvolgi in caso di grande sfasamento (consigliato)",
     "fastforwardondesync-label" : u"Avanzamento rapido in caso di ritardo (consigliato)",
-    "fastforwardondesync-label" : u"Avanzamento rapido in caso di lag (consigliato)",
     "dontslowdownwithme-label" : u"Non rallentare o riavvolgere gli altri utenti (sperimentale)",
     "pausing-title" : u"Pausa",
-    "pauseonleave-label" : u"In pausa quando gli utenti abbandonano (es. disconnessione)",
+    "pauseonleave-label" : u"Metti in pausa quando gli altri utenti abbandonano (es. disconnessione)",
     "readiness-title" : u"Stato iniziale di 'pronto'",
     "readyatstart-label" : u"Impostami sempre su 'pronto a guardare'",
-    "forceguiprompt-label" : u"Non mostrare la finestra di configurazione di Syncplay ad ogni apertura", # (Inverted)
+    "forceguiprompt-label" : u"Non mostrare la finestra di configurazione di Syncplay a ogni apertura", # (Inverted)
     "showosd-label" : u"Abilita i messaggi OSD",
 
-    "showosdwarnings-label" : u"Includi gli avvisi (es. file differenti, utenti non pronti)",
-    "showsameroomosd-label" : u"Includi gli eventi della tua stanza",
-    "shownoncontrollerosd-label" : u"Includi gli eventi dei non gestori nelle stanze gestite",
-    "showdifferentroomosd-label" : u"Includi gli eventi di altre stanze",
-    "showslowdownosd-label" : u"Includi le notifiche di rallentamento / riavvolgimento",
+    "showosdwarnings-label" : u"Mostra gli avvisi (es. file differenti, utenti non pronti)",
+    "showsameroomosd-label" : u"Mostra gli eventi della tua stanza",
+    "shownoncontrollerosd-label" : u"Mostra gli eventi dei non gestori nelle stanze gestite",
+    "showdifferentroomosd-label" : u"Mostra gli eventi di altre stanze",
+    "showslowdownosd-label" : u"Mostra le notifiche di rallentamento / riavvolgimento",
     "language-label" : u"Lingua:",
     "automatic-language" : u"Predefinita ({})", # Default language
     "showdurationnotification-label" : u"Avvisa in caso di mancata corrispondenza della durata del file",
     "basics-label" : u"Generali",
     "readiness-label" : u"Play/Pausa",
-    "misc-label" : u"Miscellanea",
+    "misc-label" : u"Varie",
     "core-behaviour-title" : u"Comportamento principale della stanza",
-    "syncplay-internals-title" : u"Comportamento Syncplay",
-    "syncplay-mediasearchdirectories-title" : u"Cartelle contenenti i file multimediali (un solo percorso per riga)",
-    "sync-label" : u"Sync", # don't have better options as the label won't fit in the panel.
-    "sync-otherslagging-title" : u"Se gli altri partecipanti laggano...",
-    "sync-youlaggging-title" : u"Se stai laggando...",
+    "syncplay-internals-title" : u"Funzionamento di Syncplay",
+    "syncplay-mediasearchdirectories-title" : u"Cartelle contenenti i file multimediali",
+    "syncplay-mediasearchdirectories-label" : u"Cartelle contenenti i file multimediali (un solo percorso per riga)",    
+    "sync-label" : u"Sincronia", # don't have better options as the label won't fit in the panel.
+    "sync-otherslagging-title" : u"Se gli altri partecipanti non sono sincronizzati...",
+    "sync-youlaggging-title" : u"Se tu sei non sei sincronizzato...",
     "messages-label" : u"Messaggi",
     "messages-osd-title" : u"Impostazioni On-screen Display",
     "messages-other-title" : u"Altre impostazioni dello schermo",
@@ -240,10 +240,10 @@ it = {
     "unpause-ifothersready-option" : u"Riprendi la riproduzione se eri già pronto o se gli altri partecipanti sono pronti (default)",
     "unpause-ifminusersready-option" : u"Riprendi la riproduzione se eri già pronto o se un numero minimo di partecipanti è pronto",
     "unpause-always" : u"Riprendi sempre la riproduzione",
-    "syncplay-trusteddomains-title": u"Domini Trusted (per servizi di streaming e contenuti in rete)",
+    "syncplay-trusteddomains-title": u"Domini fidati (per streaming e i contenuti in rete)",
 
     "chat-title" : u"Inserimento messaggi di chat",
-    "chatinputenabled-label" : u"Abilita la chat tramite mpv",
+    "chatinputenabled-label" : u"Abilita la chat su mpv",
     "chatdirectinput-label" : u"Abilita la chat istantanea (evita di dover premere Invio per chattare)",
     "chatinputfont-label" : u"Font dell'input della chat",
     "chatfont-label" : u"Imposta font",
@@ -254,14 +254,14 @@ it = {
     "chat-bottom-option" : u"In basso",
     "chatoutputheader-label" : u"Output messaggi di chat",
     "chatoutputfont-label": u"Font dell'output della chat",
-    "chatoutputenabled-label": u"Abilita l'output della chat nel media player (al momento supporta solo mpv)",
-    "chatoutputposition-label": u"Modalità output",
+    "chatoutputenabled-label": u"Abilita l'output della chat nel media player (al momento solo mpv è supportato)",
+    "chatoutputposition-label": u"Modalità di output",
     "chat-chatroom-option": u"Stile chatroom",
     "chat-scrolling-option": u"A scorrimento",
 
     "mpv-key-tab-hint": u"[TAB] to toggle access to alphabet row key shortcuts.", # TODO needs to clarify this
     "mpv-key-hint": u"[Invio] per inviare un messaggio. [Esc] per uscire dalla modalità chat.",
-    "alphakey-mode-warning-first-line": u"Puoi utilizzare temporaneamente i vecchi bindings di mpv con i tasti a-z.",
+    "alphakey-mode-warning-first-line": u"Puoi utilizzare temporaneamente i vecchi comandi di mpv con i tasti a-z.",
     "alphakey-mode-warning-second-line": u"Premi [TAB] per ritornare alla modalità chat di Syncplay.",
 
     "help-label" : u"Aiuto",
@@ -269,12 +269,12 @@ it = {
     "run-label" : u"Avvia Syncplay",
     "storeandrun-label" : u"Salva la configurazione e avvia Syncplay",
 
-    "contact-label" : u"Sentiti libero di inviare una e-mail a <a href=\"mailto:dev@syncplay.pl\"><nobr>dev@syncplay.pl</nobr></a>, chattare tramite il <a href=\"https://webchat.freenode.net/?channels=#syncplay\"><nobr>canale IRC #Syncplay</nobr></a> su irc.freenode.net, <a href=\"https://github.com/Uriziel/syncplay/issues\"><nobr>segnalare un problema</nobr></a> su GitHub, <a href=\"https://www.facebook.com/SyncplaySoftware\"><nobr>lasciare un like sulla nostra pagina Facebook</nobr></a>, <a href=\"https://twitter.com/Syncplay/\"><nobr>seguirci su Twitter</nobr></a>, o visitare <a href=\"http://syncplay.pl/\"><nobr>http://syncplay.pl/</nobr></a>. NOTA: i messaggi di chat non sono criptati, quindi non usare Syncplay per inviare dati sensibili.",
+    "contact-label" : u"Sentiti libero di inviare un'e-mail a <a href=\"mailto:dev@syncplay.pl\"><nobr>dev@syncplay.pl</nobr></a>, chattare tramite il <a href=\"https://webchat.freenode.net/?channels=#syncplay\"><nobr>canale IRC #Syncplay</nobr></a> su irc.freenode.net, <a href=\"https://github.com/Uriziel/syncplay/issues\"><nobr>segnalare un problema</nobr></a> su GitHub, <a href=\"https://www.facebook.com/SyncplaySoftware\"><nobr>lasciare un like sulla nostra pagina Facebook</nobr></a>, <a href=\"https://twitter.com/Syncplay/\"><nobr>seguirci su Twitter</nobr></a>, o visitare <a href=\"http://syncplay.pl/\"><nobr>http://syncplay.pl/</nobr></a>. NOTA: i messaggi di chat non sono cifrati, quindi non usare Syncplay per inviare dati sensibili.",
 
     "joinroom-label" : u"Entra nella stanza",
     "joinroom-menu-label" : u"Entra nella stanza {}",
-    "seektime-menu-label" : u"Vai a..",
-    "undoseek-menu-label" : u"Annulla vai a..",
+    "seektime-menu-label" : u"Vai a...",
+    "undoseek-menu-label" : u"Annulla vai a...",
     "play-menu-label" : u"Play",
     "pause-menu-label" : u"Pausa",
     "playbackbuttons-menu-label" : u"Mostra i controlli della riproduzione",
@@ -291,13 +291,13 @@ it = {
     "duration-heading-label" : u"Durata",
     "filename-heading-label" : u"Nome del file",
     "notifications-heading-label" : u"Notifiche",
-    "userlist-heading-label" : u"Lista di chi sta riproducendo cosa",
+    "userlist-heading-label" : u"Lista degli utenti nella stanza",
 
     "browseformedia-label" : u"Seleziona i file multimediali",
 
     "file-menu-label" : u"&File", # & precedes shortcut key
     "openmedia-menu-label" : u"&Apri file multimediali",
-    "openstreamurl-menu-label" : u"Apri &media stream URL",
+    "openstreamurl-menu-label" : u"Apri indirizzo di &rete",
     "setmediadirectories-menu-label" : u"Imposta &cartelle multimediali",
     "exit-menu-label" : u"&Esci",
     "advanced-menu-label" : u"&Avanzate",
@@ -305,32 +305,32 @@ it = {
     "setoffset-menu-label" : u"Imposta &offset",
     "createcontrolledroom-menu-label" : u"&Crea stanza gestita",
     "identifyascontroller-menu-label" : u"&Identificati come operatore della stanza",
-    "settrusteddomains-menu-label" : u"Imposta &domini Trusted",
-    "addtrusteddomain-menu-label" : u"Aggiungi {} come dominio Trusted", # Domain
+    "settrusteddomains-menu-label" : u"Imposta &domini fidati",
+    "addtrusteddomain-menu-label" : u"Aggiungi {} come dominio fidato", # Domain
 
     "playback-menu-label" : u"&Riproduzione",
 
     "help-menu-label" : u"&Aiuto",
     "userguide-menu-label" : u"Apri guida &utente",
-    "update-menu-label" : u"Controlla nuovi &aggiornamenti",
+    "update-menu-label" : u"Controlla la presenza di &aggiornamenti",
 
     #About dialog
     "about-menu-label": u"&Informazioni su Syncplay",
     "about-dialog-title": u"Informazioni su Syncplay",
-    "about-dialog-release": u"Versione {} release {} su {}",
-    "about-dialog-license-text" : u"Licenza Apache&nbsp;License,&nbsp;Version 2.0",
+    "about-dialog-release": u"Versione {} release {} con {}",
+    "about-dialog-license-text" : u"Rilasciato sotto Apache&nbsp;License,&nbsp;Version 2.0",
     "about-dialog-license-button": u"Licenza",
     "about-dialog-dependencies": u"Dipendenze",
 
     "setoffset-msgbox-label" : u"Imposta offset",
     "offsetinfo-msgbox-label" : u"Offset (vedi http://syncplay.pl/guide/ per istruzioni):",
 
-    "promptforstreamurl-msgbox-label" : u"Apri media stream URL",
-    "promptforstreamurlinfo-msgbox-label" : u"Stream URL",
+    "promptforstreamurl-msgbox-label" : u"Apri URL",
+    "promptforstreamurlinfo-msgbox-label" : u"Indirizzo di rete",
 
     "addfolder-label" : u"Aggiungi cartella",
 
-    "adduris-msgbox-label" : u"Aggiungi gli URL alla playlist (uno per riga)",
+    "adduris-msgbox-label" : u"Aggiungi gli indirizzi alla playlist (uno per riga)",
     "editplaylist-msgbox-label" : u"Imposta playlist (una per riga)",
     "trusteddomains-msgbox-label" : u"Domini a cui è lecito passare automaticamente (uno per riga)",
 
@@ -346,47 +346,47 @@ it = {
 
     # Tooltips
 
-    "host-tooltip" : u"Hostname o indirizzo IP a cui collegarsi e, se necessaria, includere la porta (es. syncplay.pl:8999). La sincronizzazione avviene solo con gli utenti sullo stesso server/porta.",
-    "name-tooltip" : u"Il nickname con cui sarai riconosciuto. Nessuna registrazione necessaria, cosi potrai sempre cambiarlo. Se lasciato vuoto, viene scelto un nome casuale.",
+    "host-tooltip" : u"Hostname o indirizzo IP a cui collegarsi e, se necessario, includere la porta (es. syncplay.pl:8999). La sincronizzazione avviene solo con gli utenti collegati allo stesso server/porta.",
+    "name-tooltip" : u"Il nome utente con cui sarai riconosciuto. Nessuna registrazione necessaria, cosi potrai sempre cambiarlo. Se lasciato vuoto, viene scelto un nome casuale.",
     "password-tooltip" : u"La password è necessaria solo in caso di connessione a server privati.",
     "room-tooltip" : u"La stanza in cui entrare dopo la connessione. Può assumere qualsiasi nome, ma ricorda che sarai sincronizzato solo con gli utenti nella stessa stanza.",
 
     "executable-path-tooltip" : u"Percorso del media player desiderato (scegliere tra mpv, VLC, MPC-HC/BE or mplayer2).",
     "media-path-tooltip" : u"Percorso del video o stream da aprire. Necessario per mplayer2.",
     "player-arguments-tooltip" : u"Argomenti da linea di comando aggiuntivi da passare al media player scelto.",
-    "mediasearcdirectories-arguments-tooltip" : u"Cartelle dove Syncplay ricercherà i file multimediali, es. quando usi la feature click to switch. Syncplay ricercherà ricorsivamente nelle sottocartelle.",
+    "mediasearcdirectories-arguments-tooltip" : u"Cartelle dove Syncplay cercherà i file multimediali, es. quando usi la funzione click to switch. Syncplay cercherà anche nelle sottocartelle.",
 
     "more-tooltip" : u"Mostra le impostazioni usate meno frequentemente.",
-    "filename-privacy-tooltip" : u"Modalità privacy per inviare il nome del file attualmente in riproduzione al server.",
-    "filesize-privacy-tooltip" : u"Modalità privacy per inviare la dimensione del file attualmente in riproduzione al server.",
-    "privacy-sendraw-tooltip" : u"Invia questa informazione senza offuscamento. Questa è l'impostazione predefinita per la maggior parte delle funzionalità.",
-    "privacy-sendhashed-tooltip" : u"Invia una versione criptata dell'informazione, rendendola meno visibile agli altri client.",
-    "privacy-dontsend-tooltip" : u"Non inviare questa informazione al server. Ciò garantisce massima privacy.",
+    "filename-privacy-tooltip" : u"Modalità di invio al server del nome del file attualmente in riproduzione.",
+    "filesize-privacy-tooltip" : u"Modalità di invio al server della dimensione del file attualmente in riproduzione.",
+    "privacy-sendraw-tooltip" : u"Invia questa informazione in chiaro. Questa è l'impostazione predefinita per la maggior parte delle funzionalità.",
+    "privacy-sendhashed-tooltip" : u"Invia una versione cifrata dell'informazione, rendendola meno visibile agli altri client.",
+    "privacy-dontsend-tooltip" : u"Non inviare questa informazione al server. Questo garantisce massima privacy.",
     "checkforupdatesautomatically-tooltip" : u"Controlla regolarmente la presenza di nuove versioni di Syncplay.",
-    "slowondesync-tooltip" : u"Riduce temporaneamente il rateo di riproduzione quando c'è bisogno di sincronizzarti con gli altri spettatori. Non supportato su MPC-HC/BE.",
-    "dontslowdownwithme-tooltip" : u"Gli altri utenti non vengono rallentati o riavvolti se stai laggando. Utile per i gestori della stanza.",
+    "slowondesync-tooltip" : u"Riduce temporaneamente la velocità di riproduzione quando c'è bisogno di sincronizzarti con gli altri utenti. Non supportato su MPC-HC/BE.",
+    "dontslowdownwithme-tooltip" : u"Gli altri utenti non vengono rallentati se non sei sincronizzato. Utile per i gestori della stanza.",
     "pauseonleave-tooltip" : u"Mette in pausa la riproduzione se vieni disconnesso o se qualcuno lascia la stanza.",
-    "readyatstart-tooltip" : u"Imposta il tuo stato su 'pronto' all'avvio (in caso contrario, sarai su 'non pronto' fintanto che non cambierai il tuo stato)",
-    "forceguiprompt-tooltip" : u"Il dialogo di configurazione non viene mostrato quando apri un file con Syncplay.", # (Inverted)
-    "nostore-tooltip" : u"Avvia Syncplay con la configurazione scelta, ma non salva permanentemente le impostazioni.", # (Inverted)
+    "readyatstart-tooltip" : u"Imposta il tuo stato su 'pronto' all'avvio (in caso contrario, sarai su 'non pronto' finché non cambierai il tuo stato)",
+    "forceguiprompt-tooltip" : u"La finestra di configurazione non viene mostrata quando apri Syncplay.",
+    "nostore-tooltip" : u"Avvia Syncplay con la configurazione scelta, ma non salva le impostazioni.",
     "rewindondesync-tooltip" : u"Torna indietro quando necessario per ristabilire la sincronizzazione. Disabilitare quest'opzione può causare gravi problemi di sincronizzazione!",
     "fastforwardondesync-tooltip" : u"Avanza rapidamente quando non sei sincronizzato col gestore della stanza (o la tua posizione supposta se 'Non rallentare o riavvolgere gli altri utenti' è abilitato).",
     "showosd-tooltip" : u"Invia i messaggi di Syncplay all'OSD del media player.",
-    "showosdwarnings-tooltip" : u"Mostra gli avvisi in caso di riproduzione di: un file differente, unico utente nella stanza, utenti non pronti, etc.",
+    "showosdwarnings-tooltip" : u"Mostra gli avvisi in caso di riproduzione di un file differente, se sei l'unico utente nella stanza, se ci sono utenti non pronti, ecc.",
     "showsameroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alla stanza in cui si trova l'utente.",
     "shownoncontrollerosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi ai non operatori presenti nelle stanze gestite.",
-    "showdifferentroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alla stanza in cui l'utente non si trova.",
-    "showslowdownosd-tooltip" : u"Mostra le notifiche di rallentamento / inversione in caso di differenza temporale.",
-    "showdurationnotification-tooltip" : u"Utile quando manca un segmento di un file multiparte. Può risultare in falsi positivi.",
+    "showdifferentroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alle stanze in cui l'utente non si trova.",
+    "showslowdownosd-tooltip" : u"Mostra le notifiche di rallentamento / riavvolgimento in caso di differenza temporale.",
+    "showdurationnotification-tooltip" : u"Utile quando manca un segmento di un file multiparte. Può causare dei falsi positivi.",
     "language-tooltip" : u"Lingua da utilizzare in Syncplay.",
-    "unpause-always-tooltip" : u"Se riprendi la riproduzione il tuo stato cambia in 'pronto' e la pausa viene interrotta, piuttosto che impostarti solo su pronto.",
-    "unpause-ifalreadyready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', verrai impostato su pronto - riprendi la riproduzione ancora una volta per uscire dalla pausa.",
-    "unpause-ifothersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto' la pausa verrà interrotta solo se gli altri sono pronti.",
-    "unpause-ifminusersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', la pausa verrà interrotta solo se un numero minimo di utenti è 'pronto'.",
+    "unpause-always-tooltip" : u"Se riprendi la riproduzione, il tuo stato cambia in 'pronto' e la riproduzione viene avviata, piuttosto che impostarti solo su pronto.",
+    "unpause-ifalreadyready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', verrai impostato su pronto - ripeti il comando ancora una volta per avviare la riproduzione.",
+    "unpause-ifothersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto' la riproduzione verrà avviata solo se gli altri sono pronti.",
+    "unpause-ifminusersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', la riproduzione verrà avviata solo se un numero minimo di utenti è 'pronto'.",
     "trusteddomains-arguments-tooltip" : u"Domini verso cui è possibile collegarsi automaticamente quando le playlist condivise sono abilitate.",
 
-    "chatinputenabled-tooltip" : u"Abilita l'input della chat in mpv (premi Invio per chattare, per inviare ed escape per cancellare)",
-    "chatdirectinput-tooltip" : u"Evita di dover premere Invio per aprire l'input della chat in mpv. Premi TAB in mpv per disabilitare temporaneamente questa feature.",
+    "chatinputenabled-tooltip" : u"Abilita l'input della chat in mpv (premi Invio per chattare, per inviare ed Esc per cancellare)",
+    "chatdirectinput-tooltip" : u"Evita di dover premere Invio per aprire l'input della chat in mpv. Premi TAB in mpv per disabilitare temporaneamente questa funzione.",
     "font-label-tooltip" : u"Font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
     "set-input-font-tooltip" : u"Font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
     "set-input-colour-tooltip" : u"Colore del font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
@@ -399,22 +399,22 @@ it = {
     "set-output-font-tooltip": u"Font usato per mostrare i messaggi di chat.",
     "chatoutputmode-tooltip": u"Come sono mostrati i messaggi di chat.",
     "chatoutputmode-chatroom-tooltip": u"Mostra i nuovi messaggi di chat al di sotto di quelli precedenti.",
-    "chatoutputmode-scrolling-tooltip": u"Scrolla il testo della chat da destra a sinistra.",
+    "chatoutputmode-scrolling-tooltip": u"Scorri il testo della chat da destra a sinistra.",
 
     "help-tooltip" : u"Apri la guida utente su Syncplay.pl.",
-    "reset-tooltip" : u"Resetta tutte le impostazioni.",
-    "update-server-list-tooltip" : u"Si collega a syncplay.pl per aggiornare la lista dei server pubblici.",
+    "reset-tooltip" : u"Ripristina tutte le impostazioni.",
+    "update-server-list-tooltip" : u"Scarica la lista dei server pubblici da syncplay.pl.",
 
     "joinroom-tooltip" : u"Abbandona la stanza attuale e entra in quella specificata.",
     "seektime-msgbox-label" : u"Salta all'istante di tempo specificato (in secondi / min:sec). Usa +/- per una ricerca relativa.",
     "ready-tooltip" : u"Indica quando sei pronto a guardare.",
-    "autoplay-tooltip" : u"Riproduzione automatica quado il numero minimo di utenti è su 'pronto'.",
+    "autoplay-tooltip" : u"Riproduzione automatica quando il numero minimo di utenti è 'pronto'.",
     "switch-to-file-tooltip" : u"Doppio click per passare a {}", # Filename
     "sendmessage-tooltip" : u"Invia il messaggio alla stanza",
 
     # In-userlist notes (GUI)
-    "differentsize-note" : u"Dimensione diversa!",
-    "differentsizeandduration-note" : u"Durata e dimensione diversi!",
+    "differentsize-note" : u"Dimensione file diversa!",
+    "differentsizeandduration-note" : u"Durata e dimensione file diversi!",
     "differentduration-note" : u"Durata diversa!",
     "nofile-note" : u"(Nessun file in riproduzione)",
 
@@ -425,55 +425,55 @@ it = {
     "welcome-server-notification" : u"Benvenuto nel server Syncplay, ver. {0}",  # version
     "client-connected-room-server-notification" : u"{0}({2}) connesso alla stanza '{1}'",  # username, host, room
     "client-left-server-notification" : u"{0} ha abbandonato il server",  # name
-    "no-salt-notification" : u"NOTA BENE: In futuro, per consentire il corretto funzionamento delle password generate da questo server (per le stanze gestite) quando viene riavviato, aggiungere da linea di comando il seguente argomento prima di eseguire Syncplay server: --salt {}", #Salt
+    "no-salt-notification" : u"NOTA BENE: In futuro, per consentire il corretto funzionamento delle password generate da questo server (per le stanze gestite), aggiungi da linea di comando il seguente argomento prima di avviare il server Syncplay: --salt {}", #Salt
 
 
     # Server arguments
-    "server-argument-description" : u'Soluzione per sincronizzare la riproduzione di istanze multiple di MPlayer e MPC-HC/BE attraverso la rete. Istanza del server',
+    "server-argument-description" : u'Programma per sincronizzare la riproduzione di media player multipli attraverso la rete. Modulo server.',
     "server-argument-epilog" : u'Se non è specificata alcuna opzione saranno utilizzati i valori _config',
     "server-port-argument" : u'Porta TCP del server',
     "server-password-argument" : u'password del server',
-    "server-isolate-room-argument" : u'le stanze devono essere isolate?',
-    "server-salt-argument" : u"usare stringhe randomizzate per generare le password delle stanze gestite",
+    "server-isolate-room-argument" : u'Mantiene le stanze isolate',
+    "server-salt-argument" : u"usare stringhe casuali per generare le password delle stanze gestite",
     "server-disable-ready-argument" : u"disabilita la funzionalità 'pronto'",
-    "server-motd-argument": u"percorso del file da cui verrà letto il motd",
-    "server-chat-argument" : u"disabiliare la chat?",
+    "server-motd-argument": u"percorso del file da cui verrà letto il messaggio del giorno",
+    "server-chat-argument" : u"abilita o disabilita la chat",
     "server-chat-maxchars-argument" : u"Numero massimo di caratteri in un messaggio di chat (default è {})", # Default number of characters
-    "server-messed-up-motd-unescaped-placeholders": u"Il Message of the Day ha dei caratteri non 'escaped'. Tutti i simboli $ devono essere doppi ($$).",
-    "server-messed-up-motd-too-long": u"Il Message of the Day è troppo lungo - numero massimo di caratteri è {}, {} trovati.",
+    "server-messed-up-motd-unescaped-placeholders": u"Il messaggio del giorno ha dei caratteri non 'escaped'. Tutti i simboli $ devono essere doppi ($$).",
+    "server-messed-up-motd-too-long": u"Il messaggio del giorno è troppo lungo - numero massimo di caratteri è {}, {} trovati.",
 
     # Server errors
     "unknown-command-server-error" : u"Comando non riconosciuto {}",  # message
-    "not-json-server-error" : u"Non è una stringa in codifica json {}",  # message
+    "not-json-server-error" : u"Non è una stringa in codifica JSON {}",  # message
     "not-known-server-error" : u"Devi essere riconosciuto dal server prima di poter inviare questo comando",
     "client-drop-server-error" : u"Il client è caduto: {} -- {}",  # host, error
-    "password-required-server-error" : u"La password è necessaria",
+    "password-required-server-error" : u"È richiesta una password",
     "wrong-password-server-error" : u"La password inserita è errata",
     "hello-server-error" : u"Non ci sono abbastanza argomenti Hello",
 
     # Playlists
-    "playlist-selection-changed-notification" : u"{} ha cambiato la selezione della playlist", # Username
+    "playlist-selection-changed-notification" : u"{} ha cambiato il file selezionato nella playlist", # Username
     "playlist-contents-changed-notification" : u"{} ha aggiornato la playlist", # Username
-    "cannot-find-file-for-playlist-switch-error" : u"Impossibile trovare il file {} nelle cartelle multimediali per permettere il cambio di playlist!", # Filename
-    "cannot-add-duplicate-error" : u"Impossibile aggiungere una seconda voce per '{}' alla playlist. Duplicati non ammessi.", #Filename
-    "cannot-add-unsafe-path-error" : u"Impossibile caricare automaticamente {} perchè non è presente nei domini Trusted. Puoi passare all'inserimento manuale facendo doppio click sull'URL nella playlist, e aggiungerlo ai domini Trusted tramite File->Avanzate->Imposta domini Trusted. Cliccando col tasto destro del mouse su un URL puoi aggiungere il suo dominio come dominio Trusted tramite il menù contestuale.", # Filename
+    "cannot-find-file-for-playlist-switch-error" : u"Impossibile trovare il file {} nelle cartelle multimediali per permettere il cambio di file tramite la playlist!", # Filename
+    "cannot-add-duplicate-error" : u"Impossibile aggiungere una seconda voce per '{}' alla playlist. Non è possibile avere file duplicati.", #Filename
+    "cannot-add-unsafe-path-error" : u"Impossibile caricare automaticamente {} perché non è presente nei domini fidati. Puoi passare all'inserimento manuale facendo doppio click sull'indirizzo nella playlist, oppure aggiungerlo ai domini fidati tramite File->Avanzate->Imposta domini fidati. Cliccando col tasto destro del mouse su un indirizzo puoi impostare il suo dominio come fidato tramite il menù contestuale.", # Filename
     "sharedplaylistenabled-label" : u"Abilita le playlist condivise",
     "removefromplaylist-menu-label" : u"Rimuovi dalla playlist",
-    "shuffleremainingplaylist-menu-label" : u"Shuffle le playlist rimanenti",
-    "shuffleentireplaylist-menuu-label" : u"Shuffle l'intera playlist",
+    "shuffleremainingplaylist-menu-label" : u"Mescola i file non ancora riprodotti",
+    "shuffleentireplaylist-menuu-label" : u"Mescola l'intera playlist",
     "undoplaylist-menu-label" : u"Annulla l'ultima modifica alla playlist",
-    "addfilestoplaylist-menu-label" : u"Aggiungi i file alla fine della playlist",
-    "addurlstoplaylist-menu-label" : u"Aggiungi gli URL alla fine della playlist",
-    "editplaylist-menu-label": u"Modifica playlist",
+    "addfilestoplaylist-menu-label" : u"Aggiungi un file alla fine della playlist",
+    "addurlstoplaylist-menu-label" : u"Aggiungi un indirizzo alla fine della playlist",
+    "editplaylist-menu-label": u"Modifica la playlist",
 
     "open-containing-folder": u"Apri la cartella contenente questo file",
     "addusersfiletoplaylist-menu-label" : u"Aggiungi il file {} alla playlist", # item owner indicator # TODO needs testing
-    "addusersstreamstoplaylist-menu-label" : u"Aggiungi lo stream {} alla playlist", # item owner indicator # TODO needs testing
-    "openusersstream-menu-label" : u"Apri lo stream di {}", # [username]'s
+    "addusersstreamstoplaylist-menu-label" : u"Aggiungi l'indirizzo {} alla playlist", # item owner indicator # TODO needs testing
+    "openusersstream-menu-label" : u"Apri l'indirizzo di {}", # [username]'s
     "openusersfile-menu-label" : u"Apri il file di {}", # [username]'s
     "item-is-yours-indicator" : u"tuo", # Goes with addusersfiletoplaylist/addusersstreamstoplaylist # TODO needs testing
     "item-is-others-indicator" : u"di {}", # username - goes with addusersfiletoplaylist/addusersstreamstoplaylist # TODO needs testing
 
     "playlist-instruction-item-message" : u"Trascina qui i file per aggiungerli alla playlist condivisa.",
-    "sharedplaylistenabled-tooltip" : u"Gli operatori della stanza possono aggiunge i file ad una playlist sincronizzata per garantire che tutti i partecipanti stiano guardando la stessa cosa. Configura le cartelle multimediali alla voce 'Miscellanea'.",
+    "sharedplaylistenabled-tooltip" : u"Gli operatori della stanza possono aggiungere i file a una playlist sincronizzata per garantire che tutti i partecipanti stiano guardando la stessa cosa. Configura le cartelle multimediali alla voce 'Miscellanea'.",
 }

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -1,0 +1,479 @@
+# coding:utf8
+
+"""Italian dictionary"""
+
+it = {
+    "LANGUAGE" : u"Italiano",
+
+    # Client notifications
+    "config-cleared-notification" : u"Impostazioni resettate. I cambiamenti saranno memorizzati quando salverai una configurazione valida.",
+
+    "relative-config-notification" : u"Caricato i file di configurazione relativi: {}",
+
+    "connection-attempt-notification" : u"Tentativo di connessione a {}:{}",  # Port, IP
+    "reconnection-attempt-notification" : u"Connessione col server persa, tentativo di riconnesione in corso",
+    "disconnection-notification" : u"Disconnesso dal server",
+    "connection-failed-notification" : u"Connessione col server fallita",
+    "connected-successful-notification" : u"Connessione al server effettuata con successo",
+    "retrying-notification" : u"%s, Nuovo tentativo in %d secondi...",  # Seconds
+
+    "rewind-notification" : u"Riavvolgendo a causa della differenza temporale con {}",  # User
+    "fastforward-notification" : u"Avanzamento rapido a causa della differenza temporale con {}",  # User
+    "slowdown-notification" : u"Rallentando a causa della differenza temporale con {}",  # User
+    "revert-notification" : u"Ritornando alla velocità di riproduzione normale",
+
+    "pause-notification" : u"{} ha messo in pausa",  # User
+    "unpause-notification" : u"{} ha ripreso la riproduzione",  # User
+    "seek-notification" : u"{} è passato da {} a {}",  # User, from time, to time
+
+    "current-offset-notification" : u"Offset corrente: {} secondi",  # Offset
+
+    "media-directory-list-updated-notification" : u"Le cartelle multimediali di Syncplay sono state aggiornate.",
+
+    "room-join-notification" : u"{} è entranto nella stanza: '{}'",  # User
+    "left-notification" : u"{} ha abbandonato",  # User
+    "left-paused-notification" : u"{} ha abbandonato, {} ha messo in pausa",  # User who left, User who paused
+    "playing-notification" : u"{} sta riproducendo '{}' ({})",  # User, file, duration
+    "playing-notification/room-addendum" :  u" nella stanza: '{}'",  # Room
+
+    "not-all-ready" : u"Non pronti: {}", # Usernames
+    "all-users-ready" : u"Tutti i partecipanti sono pronti ({} utenti)", #Number of ready users
+    "ready-to-unpause-notification" : u"Ora sei pronto - premi ancora una volta il tasto pausa per riprendere la riproduzione",
+    "set-as-ready-notification" : u"Ora sei pronto",
+    "set-as-not-ready-notification" : u"Non sei pronto",
+    "autoplaying-notification" : u"Riproduzione automatica in {}...",  # Number of seconds until playback will start
+
+    "identifying-as-controller-notification" : u"Identificato come gestore della stanza con password '{}'...",
+    "failed-to-identify-as-controller-notification" : u"{} ha fallito l'identificazione come gestore della stanza.",
+    "authenticated-as-controller-notification" : u"{} autenticato come gestore della stanza",
+    "created-controlled-room-notification" : u"Stanza gestita '{}' creata con password '{}'. Per favore salva queste informazioni per una consultazione futura!", # RoomName, operatorPassword
+
+    "file-different-notification" : u"Il file che stai riproducendo sembra essere diverso da quello di {}",  # User
+    "file-differences-notification" : u"Il tuo file possiede le seguenti differenze: {}", # Differences
+    "room-file-differences" : u"Differenze nel tuo file: {}", # File differences (filename, size, and/or duration)
+    "file-difference-filename" : u"nome",
+    "file-difference-filesize" : u"dimensione",
+    "file-difference-duration" : u"durata",
+    "alone-in-the-room": u"Non ci sono altri utenti nella stanza",
+
+    "different-filesize-notification" : u" (la dimensione del tuo file è diversa da quella degli altri partecipanti!)",
+    "userlist-playing-notification" : u"{} sta riproducendo:", #Username
+    "file-played-by-notification" : u"File: {} è in riproduzione da:",  # File
+    "no-file-played-notification" : u"{} non sta riproducendo alcun file", # Username
+    "notplaying-notification" : u"Partecipanti che non stanno riproducendo alcun file:",
+    "userlist-room-notification" :  u"Nella stanza '{}':",  # Room
+    "userlist-file-notification" : u"File",
+    "controller-userlist-userflag" : u"Gestore",
+    "ready-userlist-userflag" : u"Pronto",
+
+    "update-check-failed-notification" : u"Controllo automatico degli aggiornamenti di Syncplay {} fallito. Vuoi visitare http://syncplay.pl/ per verificare manualmente la presenza di aggiornamenti?", #Syncplay version
+    "syncplay-uptodate-notification" : u"Syncplay è aggiornato",
+    "syncplay-updateavailable-notification" : u"Nuova versione di Syncplay disponibile. Vuoi visitare la pagina delle release?",
+
+    "mplayer-file-required-notification" : u"Utilizzare Syncplay con mplayer richiede la selezione del file all'avvio",
+    "mplayer-file-required-notification/example" : u"Esempio di utilizzo: syncplay [opzioni] [url|percorso/]nomefile",
+    "mplayer2-required" : u"Syncplay non è compatibile con MPlayer 1.x, per favore utilizza mplayer2 or mpv",
+
+    "unrecognized-command-notification" : u"Comando non riconosciuto",
+    "commandlist-notification" : u"Comandi disponibili:",
+    "commandlist-notification/room" : u"\tr [nome] - cambia stanza",
+    "commandlist-notification/list" : u"\tl - mostra la lista di utenti",
+    "commandlist-notification/undo" : u"\tu - annulla l'ultima ricerca",
+    "commandlist-notification/pause" : u"\tp - attiva o disattiva la pausa",
+    "commandlist-notification/seek" : u"\t[s][+-]tempo - salta all'istante di tempo dato, se + o - non è specificato si considera il tempo assoluto in secondi o min:sec",
+    "commandlist-notification/help" : u"\th - questo help",
+    "commandlist-notification/toggle" : u"\tt - attiva o disattiva lo stato 'Pronto'",
+    "commandlist-notification/create" : u"\tc [nome] - crea una stanza gestita usando il nome della stanza attuale",
+    "commandlist-notification/auth" : u"\ta [password] - autentica come gestore della stanza, utilizzando la password del gestore",
+    "commandlist-notification/chat" : u"\tch [message] - invia un messaggio nella chat della stanza",
+    "syncplay-version-notification" : u"Versione di Syncplay: {}",  # syncplay.version
+    "more-info-notification" : u"Maggiori informazioni a: {}",  # projectURL
+
+    "gui-data-cleared-notification" : u"Syncplay ha resettato i dati, usati dalla GUI, relativi ai percorsi ed allo stato delle finestre.",
+    "language-changed-msgbox-label" : u"La lingua sarà cambiata quando avvierai Syncplay.",
+    "promptforupdate-label" : u"Ti piacerebbe che, di tanto in tanto, Syncplay controllasse automaticamente la presenza di aggiornamenti?",
+
+    "vlc-interface-version-mismatch": u"Stai eseguendo la versione {} del modulo di interfaccia per VLC di Syncplay, ma Syncplay è progettato per essere utilizzato con la versione {} o superiore. Per favore, fai riferimento alla User Guide di Syncplay presso http://syncplay.pl/guide/ per istruzioni su come installare syncplay.lua.",  # VLC interface version, VLC interface min version
+    "vlc-interface-oldversion-warning": u"Attenzione: Syncplay ha rilevato una vecchia versione del modulo di interfaccia per VLC di Syncplay installata nella cartella di VLC. Per favore, fai riferimento alla User Guide di Syncplay presso http://syncplay.pl/guide/ per istruzioni su come installare syncplay.lua.",
+    "media-player-latency-warning": u"Attenzione: il media player ha impiegato {} secondi per rispondere. Se stai avendo problemi di sincronizzazione, chiudi delle applicazioni per liberare le risorse di sistema e, se ciò non dovesse avere alcun effetto, prova un altro media player.", # Seconds to respond
+    "vlc-interface-not-installed": u"Attenzione: il modulo di interfaccia per VLC di Syncplay non è stato trovato nella cartella di VLC. Se stai utilizzando VLC 2.0, VLC userà il modulo syncplay.lua contenuto nella cartella di Syncplay, ma ciò significa che altri custom script di interfaccia ed estensioni non funzioneranno. Per favore, fai riferimento alla User Guide di Syncplay presso http://syncplay.pl/guide/ per istruzioni su come installare syncplay.lua.",
+    "mpv-unresponsive-error": u"mpv non ha risposto per {} secondi, quindi sembra non funzionare correttamente. Per favore, riavvia Syncplay.", # Seconds to respond
+
+    # Client prompts
+    "enter-to-exit-prompt" : u"Premi Invio per uscire\n",
+
+    # Client errors
+    "missing-arguments-error" : u"Alcuni argomenti obbligatori non sono stati trovati. Fai riferimento a --help",
+    "server-timeout-error" : u"Connessione col server scaduta",
+    "mpc-slave-error" : u"Non è possibile avviare MPC in modalità slave!",
+    "mpc-version-insufficient-error" : u"Versione di MPC non sufficiente, per favore usa `mpc-hc` >= `{}`",
+    "mpc-be-version-insufficient-error" : u"Versione di MPC non sufficiente, per favore usa `mpc-be` >= `{}`",
+    "mpv-version-error" : u"Syncplay non è compatibile con questa versione di mpv. Per favore usa un'altra versione di mpv (es. Git HEAD).",
+    "player-file-open-error" : u"Il player non è riuscito ad aprire il file",
+    "player-path-error" : u"Il path del player non è configurato correttamente. I player supportati sono: mpv, VLC, MPC-HC, MPC-BE e mplayer2",
+    "hostname-empty-error" : u"Hostname non può essere vuoto",
+    "empty-error" : u"{} non può esssere vuoto",  # Configuration
+    "media-player-error": u"Errore media player: \"{}\"",  # Error line
+    "unable-import-gui-error": u"Non è possibile importare le librerie GUI. Hai bisogno di PySide per poter utilizzare la GUI.",
+
+    "arguments-missing-error" : u"Alcuni argomenti obbligatori non sono stati trovati. Fai riferimento a --help",
+
+    "unable-to-start-client-error" : u"Impossibile avviare il client",
+
+    "player-path-config-error": u"Il path del player non è configurato correttamente. I player supportati sono: mpv, VLC, MPC-HC, MPC-BE e mplayer2.",
+    "no-file-path-config-error" :u"Deve essere selezionato un file prima di avviare il player",
+    "no-hostname-config-error": u"Hostname non può essere vuoto",
+    "invalid-port-config-error" : u"La porta deve essere valida",
+    "empty-value-config-error" : u"{} non può essere vuoto", # Config option
+
+    "not-json-error" : u"Non è una stringa con codifica JSON\n",
+    "hello-arguments-error" : u"Argomenti Hello non sufficienti\n",
+    "version-mismatch-error" : u"La versione del client è diversa da quella del server\n",
+    "vlc-failed-connection": u"Impossibile collegarsi a VLC. Se non hai installato syncplay.lua e stai usando l'ultima versione di VLC, fai riferimento a http://syncplay.pl/LUA/ per istruzioni.",
+    "vlc-failed-noscript": u"VLC ha segnalato che lo script di interfaccia syncplay.lua non è stato installato. Per favore, fai riferimento a http://syncplay.pl/LUA/ per istruzioni.",
+    "vlc-failed-versioncheck": u"Questa versione di VLC non è supportata da Syncplay.",
+
+    "feature-sharedPlaylists" : u"playlist condivise", # used for not-supported-by-server-error
+    "feature-chat" : u"chat", # used for not-supported-by-server-error
+    "feature-readiness" : u"pronto", # used for not-supported-by-server-error
+    "feature-readiness" : u"pronto", # used for not-supported-by-server-error
+    "feature-managedRooms" : u"stanze gestite", # used for not-supported-by-server-error
+
+    "not-supported-by-server-error" : u"La feature {} non è supportata da questo server..", #feature
+    "shared-playlists-not-supported-by-server-error" : u"La feature playlist condivise potrebbe non essere supportata dal server. Si necessita di un server avente Syncplay {}+ per assicurarsi che essa funzioni correttamente, tuttavia il server sta utilizzando Syncplay {}.", #minVersion, serverVersion
+    "shared-playlists-disabled-by-server-error" : u"La feature playlist condivise è stata disabilitata nella configurazione del server. Per utilizzarla, dovrai collegarti ad un altro server.",
+
+    "invalid-seek-value" : u"Valore di ricerca non valido",
+    "invalid-offset-value" : u"Valore di offset non valido",
+
+    "switch-file-not-found-error" : u"Impossibile passare al file '{0}'. Syncplay analizza le cartelle multimediali specificate.", # File not found
+    "folder-search-timeout-error" : u"La ricerca nelle cartelle multimediali è stata interrotta siccome l'analisi di '{}' sta impiegando troppo tempo. Ciò accade se si aggiunge una cartella con troppe sottocartelle nella lista di ricerca. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali nella barra dei menù e rimuovi questa cartella o sostituiscila con una sottocartella appropriata. Se la cartella è idonea, è possibile riabilitarla selezionando File->Imposta cartelle multimediali e premendo 'OK'.", #Folder
+    "folder-search-first-file-timeout-error" : u"La ricerca dei media in '{}' è stata interrotta siccome l'accesso alla cartella sta impiegando troppo tempo. Ciò accade se essa è un disco di rete oppure se hai impostato il blocco della rotazione del disco rigido dopo un certo periodo di inattività. Per riabilitare la selezione automatica dei file seleziona File->Imposta cartelle multimediali, quindi rimuovi la cartella oppure risolvi il problema (es. cambiando le impostazioni del risparmio energetico).", #Folder
+    "added-file-not-in-media-directory-error" : u"Hai selezionato un file in '{}'. Essa non è una cartella multimediale conosciuta. Puoi aggiungerla come cartella multimediale selezionando File->Imposta cartelle multimediali nella barra dei menù.", #Folder
+    "no-media-directories-error" : u"Nessuna cartella multimediale è stata configurata. Per permette il corretto funzionamento delle feature playlist condivise e selezione automatica dei file, naviga in File->Imposta cartelle multimediali e specifica dove Syncplay debba ricercare i file multimediali.",
+    "cannot-find-directory-error" : u"Impossibile trovare la cartella multimediale '{}'. Per aggiornare la lista delle cartelle multimediali seleziona File->Imposta cartelle multimediali dalla barra dei menù e specifica dove Syncplay debba ricercare i file multimediali.",
+
+    "failed-to-load-server-list-error" : u"Impossibile caricare la lista dei server pubblici. Per favore, visita http://www.syncplay.pl/ col tuo browser.",
+
+    # Client arguments
+    "argument-description" : u'Soluzione per sincronizzare la riproduzione di istanze di media player multiple attraverso la rete.',
+    "argument-epilog" : u'Se non è specificata alcuna opzione saranno utilizzati i valori _config',
+    "nogui-argument" : u'non mostrare la GUI',
+    "host-argument" : u'indirizzo del server',
+    "name-argument" : u'username desiderato',
+    "debug-argument" : u'modalità debug',
+    "force-gui-prompt-argument" : u'mostra il prompt di configurazione',
+    "no-store-argument" : u'non salva i valori in .syncplay',
+    "room-argument" : u'stanza di default',
+    "password-argument" : u'password del server',
+    "player-path-argument" : u'percorso dell\'eseguibile del tuo player',
+    "file-argument" : u'file da riprodurre',
+    "args-argument" : u'opzioni del player, se hai bisogno di passare opzioni che iniziano con - anteponile con un singolo \'--\'',
+    "clear-gui-data-argument" : u'resetta il percorso e i dati inerenti allo stato della GUI salvati come QSettings',
+    "language-argument" : u'lingua per i messaggi di Syncplay (de/en/ru)',
+
+    "version-argument" : u'mostra la tua versione',
+    "version-message" : u"Stai usando la versione di Syncplay {} ({})",
+
+    # Client labels
+    "config-window-title" : u"Configurazione di Syncplay",
+
+    "connection-group-title" : u"Impostazioni di connessione",
+    "host-label" : u"Indirizzo del server: ",
+    "name-label" : u"Username (opzionale):",
+    "password-label" : u"Password del server (se necessaria):",
+    "room-label" : u"Stanza di default: ",
+
+    "media-setting-title" : u"Impostazioni del media player",
+    "executable-path-label" : u"Percorso del media player:",
+    "media-path-label" : u"Percorso del video (opzionale):",
+    "player-arguments-label" : u"Argomenti del player (se necessari):",
+    "browse-label" : u"Sfoglia",
+    "update-server-list-label" : u"Aggiorna lista",
+
+    "more-title" : u"Mostra altre impostazioni",
+    "never-rewind-value" : u"Mai",
+    "seconds-suffix" : u" secs",
+    "privacy-sendraw-option" : u"Invio semplice",
+    "privacy-sendhashed-option" : u"Invio criptato",
+    "privacy-dontsend-option" : u"Non inviare",
+    "filename-privacy-label" : u"Nome del file:",
+    "filesize-privacy-label" : u"Dimensione del file:",
+    "checkforupdatesautomatically-label" : u"Controlla automaticamente gli aggiornamenti di Syncplay",
+    "slowondesync-label" : u"Rallenta in caso di desync minimo (non supportato su MPC-HC/BE)",
+    "rewindondesync-label" : u"Riavvolgi in caso di desync grave (consigliato)",
+    "fastforwardondesync-label" : u"Avanzamento rapido in caso di ritardo (consigliato)",
+    "fastforwardondesync-label" : u"Avanzamento rapido in caso di lag (consigliato)",
+    "dontslowdownwithme-label" : u"Non rallentare o riavvolgere gli altri utenti (sperimentale)",
+    "pausing-title" : u"Pausa",
+    "pauseonleave-label" : u"In pausa quando gli utenti abbandonano (es. disconnessione)",
+    "readiness-title" : u"Stato iniziale di 'pronto'",
+    "readyatstart-label" : u"Impostami sempre su 'pronto a guardare'",
+    "forceguiprompt-label" : u"Non mostrare la finestra di configurazione di Syncplay ad ogni apertura", # (Inverted)
+    "showosd-label" : u"Abilita i messaggi OSD",
+
+    "showosdwarnings-label" : u"Includi gli avvisi (es. file differenti, utenti non pronti)",
+    "showsameroomosd-label" : u"Includi gli eventi della tua stanza",
+    "shownoncontrollerosd-label" : u"Includi gli eventi dei non gestori nelle stanze gestite",
+    "showdifferentroomosd-label" : u"Includi gli eventi di altre stanze",
+    "showslowdownosd-label" : u"Includi le notifiche di rallentamento / riavvolgimento",
+    "language-label" : u"Lingua:",
+    "automatic-language" : u"Predefinita ({})", # Default language
+    "showdurationnotification-label" : u"Avvisa in caso di mancata corrispondenza della durata del file",
+    "basics-label" : u"Generali",
+    "readiness-label" : u"Play/Pausa",
+    "misc-label" : u"Miscellanea",
+    "core-behaviour-title" : u"Comportamento principale della stanza",
+    "syncplay-internals-title" : u"Comportamento Syncplay",
+    "syncplay-mediasearchdirectories-title" : u"Cartelle contenenti i file multimediali (un solo percorso per riga)",
+    "sync-label" : u"Sync", # don't have better options as the label won't fit in the panel.
+    "sync-otherslagging-title" : u"Se gli altri partecipanti laggano...",
+    "sync-youlaggging-title" : u"Se stai laggando...",
+    "messages-label" : u"Messaggi",
+    "messages-osd-title" : u"Impostazioni On-screen Display",
+    "messages-other-title" : u"Altre impostazioni dello schermo",
+    "chat-label" : u"Chat",
+    "privacy-label" : u"Privacy", # Currently unused, but will be brought back if more space is needed in Misc tab
+    "privacy-title" : u"Impostazioni privacy",
+    "unpause-title" : u"Premendo play, imposta il tuo stato su pronto e:",
+    "unpause-ifalreadyready-option" : u"Riprendi la riproduzione se eri già pronto",
+    "unpause-ifothersready-option" : u"Riprendi la riproduzione se eri già pronto o se gli altri partecipanti sono pronti (default)",
+    "unpause-ifminusersready-option" : u"Riprendi la riproduzione se eri già pronto o se un numero minimo di partecipanti è pronto",
+    "unpause-always" : u"Riprendi sempre la riproduzione",
+    "syncplay-trusteddomains-title": u"Domini Trusted (per servizi di streaming e contenuti in rete)",
+
+    "chat-title" : u"Inserimento messaggi di chat",
+    "chatinputenabled-label" : u"Abilita la chat tramite mpv",
+    "chatdirectinput-label" : u"Abilita la chat istantanea (evita di dover premere Invio per chattare)",
+    "chatinputfont-label" : u"Font dell'input della chat",
+    "chatfont-label" : u"Imposta font",
+    "chatcolour-label" : u"Imposta colore",
+    "chatinputposition-label" : u"Posizione dell'area di inserimento testo in mpv",
+    "chat-top-option" : u"In alto",
+    "chat-middle-option" : u"Al centro",
+    "chat-bottom-option" : u"In basso",
+    "chatoutputheader-label" : u"Output messaggi di chat",
+    "chatoutputfont-label": u"Font dell'output della chat",
+    "chatoutputenabled-label": u"Abilita l'output della chat nel media player (al momento supporta solo mpv)",
+    "chatoutputposition-label": u"Modalità output",
+    "chat-chatroom-option": u"Stile chatroom",
+    "chat-scrolling-option": u"A scorrimento",
+
+    "mpv-key-tab-hint": u"[TAB] to toggle access to alphabet row key shortcuts.", # TODO needs to clarify this
+    "mpv-key-hint": u"[Invio] per inviare un messaggio. [Esc] per uscire dalla modalità chat.",
+    "alphakey-mode-warning-first-line": u"Puoi utilizzare temporaneamente i vecchi bindings di mpv con i tasti a-z.",
+    "alphakey-mode-warning-second-line": u"Premi [TAB] per ritornare alla modalità chat di Syncplay.",
+
+    "help-label" : u"Aiuto",
+    "reset-label" : u"Impostazioni iniziali",
+    "run-label" : u"Avvia Syncplay",
+    "storeandrun-label" : u"Salva la configurazione e avvia Syncplay",
+
+    "contact-label" : u"Sentiti libero di inviare una e-mail a <a href=\"mailto:dev@syncplay.pl\"><nobr>dev@syncplay.pl</nobr></a>, chattare tramite il <a href=\"https://webchat.freenode.net/?channels=#syncplay\"><nobr>canale IRC #Syncplay</nobr></a> su irc.freenode.net, <a href=\"https://github.com/Uriziel/syncplay/issues\"><nobr>segnalare un problema</nobr></a> su GitHub, <a href=\"https://www.facebook.com/SyncplaySoftware\"><nobr>lasciare un like sulla nostra pagina Facebook</nobr></a>, <a href=\"https://twitter.com/Syncplay/\"><nobr>seguirci su Twitter</nobr></a>, o visitare <a href=\"http://syncplay.pl/\"><nobr>http://syncplay.pl/</nobr></a>. NOTA: i messaggi di chat non sono criptati, quindi non usare Syncplay per inviare dati sensibili.",
+
+    "joinroom-label" : u"Entra nella stanza",
+    "joinroom-menu-label" : u"Entra nella stanza {}",
+    "seektime-menu-label" : u"Vai a..",
+    "undoseek-menu-label" : u"Annulla vai a..",
+    "play-menu-label" : u"Play",
+    "pause-menu-label" : u"Pausa",
+    "playbackbuttons-menu-label" : u"Mostra i controlli della riproduzione",
+    "autoplay-menu-label" : u"Mostra il tasto di riproduzione automatica",
+    "autoplay-guipushbuttonlabel" : u"Riproduci quando tutti sono pronti",
+    "autoplay-minimum-label" : u"Minimo utenti pronti:",
+
+    "sendmessage-label" : u"Invia",
+
+    "ready-guipushbuttonlabel" : u"Sono pronto a guardare!",
+
+    "roomuser-heading-label" : u"Stanza / Utente",
+    "size-heading-label" : u"Dimensione",
+    "duration-heading-label" : u"Durata",
+    "filename-heading-label" : u"Nome del file",
+    "notifications-heading-label" : u"Notifiche",
+    "userlist-heading-label" : u"Lista di chi sta riproducendo cosa",
+
+    "browseformedia-label" : u"Seleziona i file multimediali",
+
+    "file-menu-label" : u"&File", # & precedes shortcut key
+    "openmedia-menu-label" : u"&Apri file multimediali",
+    "openstreamurl-menu-label" : u"Apri &media stream URL",
+    "setmediadirectories-menu-label" : u"Imposta &cartelle multimediali",
+    "exit-menu-label" : u"&Esci",
+    "advanced-menu-label" : u"&Avanzate",
+    "window-menu-label" : u"&Finestra",
+    "setoffset-menu-label" : u"Imposta &offset",
+    "createcontrolledroom-menu-label" : u"&Crea stanza gestita",
+    "identifyascontroller-menu-label" : u"&Identificati come operatore della stanza",
+    "settrusteddomains-menu-label" : u"Imposta &domini Trusted",
+    "addtrusteddomain-menu-label" : u"Aggiungi {} come dominio Trusted", # Domain
+
+    "playback-menu-label" : u"&Riproduzione",
+
+    "help-menu-label" : u"&Aiuto",
+    "userguide-menu-label" : u"Apri guida &utente",
+    "update-menu-label" : u"Controlla nuovi &aggiornamenti",
+
+    #About dialog
+    "about-menu-label": u"&Informazioni su Syncplay",
+    "about-dialog-title": u"Informazioni su Syncplay",
+    "about-dialog-release": u"Versione {} release {} su {}",
+    "about-dialog-license-text" : u"Licenza Apache&nbsp;License,&nbsp;Version 2.0",
+    "about-dialog-license-button": u"Licenza",
+    "about-dialog-dependencies": u"Dipendenze",
+
+    "setoffset-msgbox-label" : u"Imposta offset",
+    "offsetinfo-msgbox-label" : u"Offset (vedi http://syncplay.pl/guide/ per istruzioni):",
+
+    "promptforstreamurl-msgbox-label" : u"Apri media stream URL",
+    "promptforstreamurlinfo-msgbox-label" : u"Stream URL",
+
+    "addfolder-label" : u"Aggiungi cartella",
+
+    "adduris-msgbox-label" : u"Aggiungi gli URL alla playlist (uno per riga)",
+    "editplaylist-msgbox-label" : u"Imposta playlist (una per riga)",
+    "trusteddomains-msgbox-label" : u"Domini a cui è lecito passare automaticamente (uno per riga)",
+
+    "createcontrolledroom-msgbox-label" : u"Crea stanza gestita",
+    "controlledroominfo-msgbox-label" : u"Inserisci il nome della stanza gestita\r\n(vedi http://syncplay.pl/guide/ per istruzioni):",
+
+    "identifyascontroller-msgbox-label" : u"Identificati come operatore della stanza",
+    "identifyinfo-msgbox-label" : u"Inserisci la password dell'operatore per questa stanza\r\n(vedi http://syncplay.pl/guide/ per istruzioni):",
+
+    "public-server-msgbox-label" : u"Seleziona il server pubblico per questa sessione",
+
+    "megabyte-suffix" : u" MB",
+
+    # Tooltips
+
+    "host-tooltip" : u"Hostname o indirizzo IP a cui collegarsi e, se necessaria, includere la porta (es. syncplay.pl:8999). La sincronizzazione avviene solo con gli utenti sullo stesso server/porta.",
+    "name-tooltip" : u"Il nickname con cui sarai riconosciuto. Nessuna registrazione necessaria, cosi potrai sempre cambiarlo. Se lasciato vuoto, viene scelto un nome casuale.",
+    "password-tooltip" : u"La password è necessaria solo in caso di connessione a server privati.",
+    "room-tooltip" : u"La stanza in cui entrare dopo la connessione. Può assumere qualsiasi nome, ma ricorda che sarai sincronizzato solo con gli utenti nella stessa stanza.",
+
+    "executable-path-tooltip" : u"Percorso del media player desiderato (scegliere tra mpv, VLC, MPC-HC/BE or mplayer2).",
+    "media-path-tooltip" : u"Percorso del video o stream da aprire. Necessario per mplayer2.",
+    "player-arguments-tooltip" : u"Argomenti da linea di comando aggiuntivi da passare al media player scelto.",
+    "mediasearcdirectories-arguments-tooltip" : u"Cartelle dove Syncplay ricercherà i file multimediali, es. quando usi la feature click to switch. Syncplay ricercherà ricorsivamente nelle sottocartelle.",
+
+    "more-tooltip" : u"Mostra le impostazioni usate meno frequentemente.",
+    "filename-privacy-tooltip" : u"Modalità privacy per inviare il nome del file attualmente in riproduzione al server.",
+    "filesize-privacy-tooltip" : u"Modalità privacy per inviare la dimensione del file attualmente in riproduzione al server.",
+    "privacy-sendraw-tooltip" : u"Invia questa informazione senza offuscamento. Questa è l'impostazione predefinita per la maggior parte delle funzionalità.",
+    "privacy-sendhashed-tooltip" : u"Invia una versione criptata dell'informazione, rendendola meno visibile agli altri client.",
+    "privacy-dontsend-tooltip" : u"Non inviare questa informazione al server. Ciò garantisce massima privacy.",
+    "checkforupdatesautomatically-tooltip" : u"Controlla regolarmente la presenza di nuove versioni di Syncplay.",
+    "slowondesync-tooltip" : u"Riduce temporaneamente il rateo di riproduzione quando c'è bisogno di sincronizzarti con gli altri spettatori. Non supportato su MPC-HC/BE.",
+    "dontslowdownwithme-tooltip" : u"Gli altri utenti non vengono rallentati o riavvolti se stai laggando. Utile per i gestori della stanza.",
+    "pauseonleave-tooltip" : u"Mette in pausa la riproduzione se vieni disconnesso o se qualcuno lascia la stanza.",
+    "readyatstart-tooltip" : u"Imposta il tuo stato su 'pronto' all'avvio (in caso contrario, sarai su 'non pronto' fintanto che non cambierai il tuo stato)",
+    "forceguiprompt-tooltip" : u"Il dialogo di configurazione non viene mostrato quando apri un file con Syncplay.", # (Inverted)
+    "nostore-tooltip" : u"Avvia Syncplay con la configurazione scelta, ma non salva permanentemente le impostazioni.", # (Inverted)
+    "rewindondesync-tooltip" : u"Torna indietro quando necessario per ristabilire la sincronizzazione. Disabilitare quest'opzione può causare gravi problemi di sincronizzazione!",
+    "fastforwardondesync-tooltip" : u"Avanza rapidamente quando non sei sincronizzato col gestore della stanza (o la tua posizione supposta se 'Non rallentare o riavvolgere gli altri utenti' è abilitato).",
+    "showosd-tooltip" : u"Invia i messaggi di Syncplay all'OSD del media player.",
+    "showosdwarnings-tooltip" : u"Mostra gli avvisi in caso di riproduzione di: un file differente, unico utente nella stanza, utenti non pronti, etc.",
+    "showsameroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alla stanza in cui si trova l'utente.",
+    "shownoncontrollerosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi ai non operatori presenti nelle stanze gestite.",
+    "showdifferentroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alla stanza in cui l'utente non si trova.",
+    "showslowdownosd-tooltip" : u"Mostra le notifiche di rallentamento / inversione in caso di differenza temporale.",
+    "showdurationnotification-tooltip" : u"Utile quando manca un segmento di un file multiparte. Può risultare in falsi positivi.",
+    "language-tooltip" : u"Lingua da utilizzare in Syncplay.",
+    "unpause-always-tooltip" : u"Se riprendi la riproduzione il tuo stato cambia in 'pronto' e la pausa viene interrotta, piuttosto che impostarti solo su pronto.",
+    "unpause-ifalreadyready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', verrai impostato su pronto - riprendi la riproduzione ancora una volta per uscire dalla pausa.",
+    "unpause-ifothersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto' la pausa verrà interrotta solo se gli altri sono pronti.",
+    "unpause-ifminusersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', la pausa verrà interrotta solo se un numero minimo di utenti è 'pronto'.",
+    "trusteddomains-arguments-tooltip" : u"Domini verso cui è possibile collegarsi automaticamente quando le playlist condivise sono abilitate.",
+
+    "chatinputenabled-tooltip" : u"Abilita l'input della chat in mpv (premi Invio per chattare, per inviare ed escape per cancellare)",
+    "chatdirectinput-tooltip" : u"Evita di dover premere Invio per aprire l'input della chat in mpv. Premi TAB in mpv per disabilitare temporaneamente questa feature.",
+    "font-label-tooltip" : u"Font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
+    "set-input-font-tooltip" : u"Font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
+    "set-input-colour-tooltip" : u"Colore del font usato nell'input della chat in mpv. Non influenza cosa vedono gli altri, vale solo per te.",
+    "chatinputposition-tooltip" : u"Posizione dell'input della chat in mpv quando premi Invio.",
+    "chatinputposition-top-tooltip" : u"Posiziona l'input della chat in cima alla finestra di mpv.",
+    "chatinputposition-middle-tooltip" : u"Posizione l'input della chat al centro della finestra di mpv.",
+    "chatinputposition-bottom-tooltip" : u"Posiziona l'input della chat in basso alla finestra di mpv.",
+    "chatoutputenabled-tooltip": u"Mostra i messaggi di chat nell'OSD (se supportato dal media player).",
+    "font-output-label-tooltip": u"Font dell'output della chat.",
+    "set-output-font-tooltip": u"Font usato per mostrare i messaggi di chat.",
+    "chatoutputmode-tooltip": u"Come sono mostrati i messaggi di chat.",
+    "chatoutputmode-chatroom-tooltip": u"Mostra i nuovi messaggi di chat al di sotto di quelli precedenti.",
+    "chatoutputmode-scrolling-tooltip": u"Scrolla il testo della chat da destra a sinistra.",
+
+    "help-tooltip" : u"Apri la guida utente su Syncplay.pl.",
+    "reset-tooltip" : u"Resetta tutte le impostazioni.",
+    "update-server-list-tooltip" : u"Si collega a syncplay.pl per aggiornare la lista dei server pubblici.",
+
+    "joinroom-tooltip" : u"Abbandona la stanza attuale e entra in quella specificata.",
+    "seektime-msgbox-label" : u"Salta all'istante di tempo specificato (in secondi / min:sec). Usa +/- per una ricerca relativa.",
+    "ready-tooltip" : u"Indica quando sei pronto a guardare.",
+    "autoplay-tooltip" : u"Riproduzione automatica quado il numero minimo di utenti è su 'pronto'.",
+    "switch-to-file-tooltip" : u"Doppio click per passare a {}", # Filename
+    "sendmessage-tooltip" : u"Invia il messaggio alla stanza",
+
+    # In-userlist notes (GUI)
+    "differentsize-note" : u"Dimensione diversa!",
+    "differentsizeandduration-note" : u"Durata e dimensione diversi!",
+    "differentduration-note" : u"Durata diversa!",
+    "nofile-note" : u"(Nessun file in riproduzione)",
+
+    # Server messages to client
+    "new-syncplay-available-motd-message" : u"<NOTICE> Stai usando Syncplay {} ma una nuova versione è disponibile presso http://syncplay.pl </NOTICE>",  # ClientVersion
+
+    # Server notifications
+    "welcome-server-notification" : u"Benvenuto nel server Syncplay, ver. {0}",  # version
+    "client-connected-room-server-notification" : u"{0}({2}) connesso alla stanza '{1}'",  # username, host, room
+    "client-left-server-notification" : u"{0} ha abbandonato il server",  # name
+    "no-salt-notification" : u"NOTA BENE: In futuro, per consentire il corretto funzionamento delle password generate da questo server (per le stanze gestite) quando viene riavviato, aggiungere da linea di comando il seguente argomento prima di eseguire Syncplay server: --salt {}", #Salt
+
+
+    # Server arguments
+    "server-argument-description" : u'Soluzione per sincronizzare la riproduzione di istanze multiple di MPlayer e MPC-HC/BE attraverso la rete. Istanza del server',
+    "server-argument-epilog" : u'Se non è specificata alcuna opzione saranno utilizzati i valori _config',
+    "server-port-argument" : u'Porta TCP del server',
+    "server-password-argument" : u'password del server',
+    "server-isolate-room-argument" : u'le stanze devono essere isolate?',
+    "server-salt-argument" : u"usare stringhe randomizzate per generare le password delle stanze gestite",
+    "server-disable-ready-argument" : u"disabilita la funzionalità 'pronto'",
+    "server-motd-argument": u"percorso del file da cui verrà letto il motd",
+    "server-chat-argument" : u"disabiliare la chat?",
+    "server-chat-maxchars-argument" : u"Numero massimo di caratteri in un messaggio di chat (default è {})", # Default number of characters
+    "server-messed-up-motd-unescaped-placeholders": u"Il Message of the Day ha dei caratteri non 'escaped'. Tutti i simboli $ devono essere doppi ($$).",
+    "server-messed-up-motd-too-long": u"Il Message of the Day è troppo lungo - numero massimo di caratteri è {}, {} trovati.",
+
+    # Server errors
+    "unknown-command-server-error" : u"Comando non riconosciuto {}",  # message
+    "not-json-server-error" : u"Non è una stringa in codifica json {}",  # message
+    "not-known-server-error" : u"Devi essere riconosciuto dal server prima di poter inviare questo comando",
+    "client-drop-server-error" : u"Il client è caduto: {} -- {}",  # host, error
+    "password-required-server-error" : u"La password è necessaria",
+    "wrong-password-server-error" : u"La password inserita è errata",
+    "hello-server-error" : u"Non ci sono abbastanza argomenti Hello",
+
+    # Playlists
+    "playlist-selection-changed-notification" : u"{} ha cambiato la selezione della playlist", # Username
+    "playlist-contents-changed-notification" : u"{} ha aggiornato la playlist", # Username
+    "cannot-find-file-for-playlist-switch-error" : u"Impossibile trovare il file {} nelle cartelle multimediali per permettere il cambio di playlist!", # Filename
+    "cannot-add-duplicate-error" : u"Impossibile aggiungere una seconda voce per '{}' alla playlist. Duplicati non ammessi.", #Filename
+    "cannot-add-unsafe-path-error" : u"Impossibile caricare automaticamente {} perchè non è presente nei domini Trusted. Puoi passare all'inserimento manuale facendo doppio click sull'URL nella playlist, e aggiungerlo ai domini Trusted tramite File->Avanzate->Imposta domini Trusted. Cliccando col tasto destro del mouse su un URL puoi aggiungere il suo dominio come dominio Trusted tramite il menù contestuale.", # Filename
+    "sharedplaylistenabled-label" : u"Abilita le playlist condivise",
+    "removefromplaylist-menu-label" : u"Rimuovi dalla playlist",
+    "shuffleremainingplaylist-menu-label" : u"Shuffle le playlist rimanenti",
+    "shuffleentireplaylist-menuu-label" : u"Shuffle l'intera playlist",
+    "undoplaylist-menu-label" : u"Annulla l'ultima modifica alla playlist",
+    "addfilestoplaylist-menu-label" : u"Aggiungi i file alla fine della playlist",
+    "addurlstoplaylist-menu-label" : u"Aggiungi gli URL alla fine della playlist",
+    "editplaylist-menu-label": u"Modifica playlist",
+
+    "open-containing-folder": u"Apri la cartella contenente questo file",
+    "addusersfiletoplaylist-menu-label" : u"Aggiungi il file {} alla playlist", # item owner indicator # TODO needs testing
+    "addusersstreamstoplaylist-menu-label" : u"Aggiungi lo stream {} alla playlist", # item owner indicator # TODO needs testing
+    "openusersstream-menu-label" : u"Apri lo stream di {}", # [username]'s
+    "openusersfile-menu-label" : u"Apri il file di {}", # [username]'s
+    "item-is-yours-indicator" : u"tuo", # Goes with addusersfiletoplaylist/addusersstreamstoplaylist # TODO needs testing
+    "item-is-others-indicator" : u"di {}", # username - goes with addusersfiletoplaylist/addusersstreamstoplaylist # TODO needs testing
+
+    "playlist-instruction-item-message" : u"Trascina qui i file per aggiungerli alla playlist condivisa.",
+    "sharedplaylistenabled-tooltip" : u"Gli operatori della stanza possono aggiunge i file ad una playlist sincronizzata per garantire che tutti i partecipanti stiano guardando la stessa cosa. Configura le cartelle multimediali alla voce 'Miscellanea'.",
+}

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -6,7 +6,7 @@ it = {
     "LANGUAGE" : u"Italiano",
 
     # Client notifications
-    "config-cleared-notification" : u"Impostazioni resettate. I cambiamenti saranno memorizzati quando salverai una configurazione valida.",
+    "config-cleared-notification" : u"Impostazioni iniziali ripristinate. I cambiamenti saranno memorizzati quando salverai una configurazione valida.",
 
     "relative-config-notification" : u"Caricato i file di configurazione relativi: {}",
 
@@ -20,7 +20,7 @@ it = {
     "rewind-notification" : u"Riavvolgo a causa della differenza temporale con {}",  # User
     "fastforward-notification" : u"Avanzamento rapido a causa della differenza temporale con {}",  # User
     "slowdown-notification" : u"Rallento a causa della differenza temporale con {}",  # User
-    "revert-notification" : u"Velocità di riproduzione normale ripristinata",
+    "revert-notification" : u"Ripristino la velocità di riproduzione normale",
 
     "pause-notification" : u"{} ha messo in pausa",  # User
     "unpause-notification" : u"{} ha ripreso la riproduzione",  # User
@@ -31,26 +31,26 @@ it = {
     "media-directory-list-updated-notification" : u"Le cartelle multimediali di Syncplay sono state aggiornate.",
 
     "room-join-notification" : u"{} è entranto nella stanza: '{}'",  # User
-    "left-notification" : u"{} ha abbandonato",  # User
-    "left-paused-notification" : u"{} ha abbandonato, {} ha messo in pausa",  # User who left, User who paused
+    "left-notification" : u"{} ha lasciato la stanza",  # User
+    "left-paused-notification" : u"{} ha lasciato la stanza, {} ha messo in pausa",  # User who left, User who paused
     "playing-notification" : u"{} sta riproducendo '{}' ({})",  # User, file, duration
     "playing-notification/room-addendum" :  u" nella stanza: '{}'",  # Room
 
     "not-all-ready" : u"Non pronti: {}", # Usernames
     "all-users-ready" : u"Tutti i partecipanti sono pronti ({} utenti)", #Number of ready users
-    "ready-to-unpause-notification" : u"Ora sei pronto - premi ancora una volta il tasto pausa per riprendere la riproduzione",
+    "ready-to-unpause-notification" : u"Ora sei pronto - premi ancora una volta per riprendere la riproduzione",
     "set-as-ready-notification" : u"Ora sei pronto",
     "set-as-not-ready-notification" : u"Non sei pronto",
     "autoplaying-notification" : u"Riproduzione automatica in {}...",  # Number of seconds until playback will start
 
-    "identifying-as-controller-notification" : u"Identificato come gestore della stanza con password '{}'...",
+    "identifying-as-controller-notification" : u"Ti sei identificato come gestore della stanza con password '{}'...",
     "failed-to-identify-as-controller-notification" : u"{} ha fallito l'identificazione come gestore della stanza.",
     "authenticated-as-controller-notification" : u"{} autenticato come gestore della stanza",
     "created-controlled-room-notification" : u"Stanza gestita '{}' creata con password '{}'. Per favore salva queste informazioni per una consultazione futura!", # RoomName, operatorPassword
 
     "file-different-notification" : u"Il file che stai riproducendo sembra essere diverso da quello di {}",  # User
     "file-differences-notification" : u"Il tuo file mostra le seguenti differenze: {}", # Differences
-    "room-file-differences" : u"Differenze nel tuo file: {}", # File differences (filename, size, and/or duration)
+    "room-file-differences" : u"Differenze: {} \n", # File differences (filename, size, and/or duration)
     "file-difference-filename" : u"nome",
     "file-difference-filesize" : u"dimensione",
     "file-difference-duration" : u"durata",
@@ -82,14 +82,14 @@ it = {
     "commandlist-notification/pause" : u"\tp - attiva o disattiva la pausa",
     "commandlist-notification/seek" : u"\t[s][+-]tempo - salta all'istante di tempo dato, se + o - non è specificato si considera il tempo assoluto in secondi o min:sec",
     "commandlist-notification/help" : u"\th - mostra questo help",
-    "commandlist-notification/toggle" : u"\tt - attiva o disattiva lo stato 'Pronto'",
+    "commandlist-notification/toggle" : u"\tt - attiva o disattiva la funzionalità \"pronto\"",
     "commandlist-notification/create" : u"\tc [nome] - crea una stanza gestita usando il nome della stanza attuale",
     "commandlist-notification/auth" : u"\ta [password] - autentica come gestore della stanza, utilizzando la password del gestore",
     "commandlist-notification/chat" : u"\tch [message] - invia un messaggio nella chat della stanza",
     "syncplay-version-notification" : u"Versione di Syncplay: {}",  # syncplay.version
     "more-info-notification" : u"Maggiori informazioni a: {}",  # projectURL
 
-    "gui-data-cleared-notification" : u"Syncplay ha resettato i dati dell'interfaccia relativi ai percorsi e allo stato delle finestre.",
+    "gui-data-cleared-notification" : u"Syncplay ha ripristinato i dati dell'interfaccia relativi ai percorsi e allo stato delle finestre.",
     "language-changed-msgbox-label" : u"La lingua sarà cambiata quando avvierai Syncplay.",
     "promptforupdate-label" : u"Ti piacerebbe che, di tanto in tanto, Syncplay controllasse automaticamente la presenza di aggiornamenti?",
 
@@ -127,7 +127,7 @@ it = {
     "empty-value-config-error" : u"Il campo {} non può essere vuoto", # Config option
 
     "not-json-error" : u"Non è una stringa con codifica JSON\n",
-    "hello-arguments-error" : u"Argomenti Hello non sufficienti\n",
+    "hello-arguments-error" : "Not enough Hello arguments\n", # DO NOT TRANSLATE
     "version-mismatch-error" : u"La versione del client è diversa da quella del server\n",
     "vlc-failed-connection": u"Impossibile collegarsi a VLC. Se non hai installato syncplay.lua e stai usando l'ultima versione di VLC, fai riferimento a http://syncplay.pl/LUA/ per istruzioni.",
     "vlc-failed-noscript": u"VLC ha segnalato che lo script di interfaccia syncplay.lua non è stato installato. Per favore, fai riferimento a http://syncplay.pl/LUA/ per istruzioni.",
@@ -135,7 +135,6 @@ it = {
 
     "feature-sharedPlaylists" : u"playlist condivise", # used for not-supported-by-server-error
     "feature-chat" : u"chat", # used for not-supported-by-server-error
-    "feature-readiness" : u"pronto", # used for not-supported-by-server-error
     "feature-readiness" : u"pronto", # used for not-supported-by-server-error
     "feature-managedRooms" : u"stanze gestite", # used for not-supported-by-server-error
 
@@ -169,7 +168,7 @@ it = {
     "player-path-argument" : u'percorso dell\'eseguibile del tuo player',
     "file-argument" : u'file da riprodurre',
     "args-argument" : u'opzioni del player, se hai bisogno di utilizzare opzioni che iniziano con - anteponi un singolo \'--\'',
-    "clear-gui-data-argument" : u'resetta il percorso e i dati impostati tramite interfaccia grafica e salvati come QSettings',
+    "clear-gui-data-argument" : u'ripristina il percorso e i dati impostati tramite interfaccia grafica e salvati come QSettings',
     "language-argument" : u'lingua per i messaggi di Syncplay (de/en/ru/it)',
 
     "version-argument" : u'mostra la tua versione',
@@ -205,10 +204,10 @@ it = {
     "fastforwardondesync-label" : u"Avanzamento rapido in caso di ritardo (consigliato)",
     "dontslowdownwithme-label" : u"Non rallentare o riavvolgere gli altri utenti (sperimentale)",
     "pausing-title" : u"Pausa",
-    "pauseonleave-label" : u"Metti in pausa quando gli altri utenti abbandonano (es. disconnessione)",
+    "pauseonleave-label" : u"Metti in pausa quando gli altri utenti lasciano la stanza (es. disconnessione)",
     "readiness-title" : u"Stato iniziale di 'pronto'",
-    "readyatstart-label" : u"Impostami sempre su 'pronto a guardare'",
-    "forceguiprompt-label" : u"Non mostrare la finestra di configurazione di Syncplay a ogni apertura", # (Inverted)
+    "readyatstart-label" : u"Imposta sempre il mio stato come \"pronto\" a guardare",
+    "forceguiprompt-label" : u"Non mostrare la finestra di configurazione di Syncplay a ogni avvio", # (Inverted)
     "showosd-label" : u"Abilita i messaggi OSD",
 
     "showosdwarnings-label" : u"Mostra gli avvisi (es. file differenti, utenti non pronti)",
@@ -230,12 +229,12 @@ it = {
     "sync-otherslagging-title" : u"Se gli altri partecipanti non sono sincronizzati...",
     "sync-youlaggging-title" : u"Se tu sei non sei sincronizzato...",
     "messages-label" : u"Messaggi",
-    "messages-osd-title" : u"Impostazioni On-screen Display",
+    "messages-osd-title" : u"Impostazioni On-Screen Display",
     "messages-other-title" : u"Altre impostazioni dello schermo",
     "chat-label" : u"Chat",
     "privacy-label" : u"Privacy", # Currently unused, but will be brought back if more space is needed in Misc tab
     "privacy-title" : u"Impostazioni privacy",
-    "unpause-title" : u"Premendo play, imposta il tuo stato su pronto e:",
+    "unpause-title" : u"Premendo play, imposta il tuo stato su \"pronto\" e:",
     "unpause-ifalreadyready-option" : u"Riprendi la riproduzione se eri già pronto",
     "unpause-ifothersready-option" : u"Riprendi la riproduzione se eri già pronto o se gli altri partecipanti sono pronti (default)",
     "unpause-ifminusersready-option" : u"Riprendi la riproduzione se eri già pronto o se un numero minimo di partecipanti è pronto",
@@ -259,13 +258,13 @@ it = {
     "chat-chatroom-option": u"Stile chatroom",
     "chat-scrolling-option": u"A scorrimento",
 
-    "mpv-key-tab-hint": u"[TAB] to toggle access to alphabet row key shortcuts.", # TODO needs to clarify this
+    "mpv-key-tab-hint": u"[TAB] per attivare le scorciatoie da tastiera e disattivare la chat.",
     "mpv-key-hint": u"[Invio] per inviare un messaggio. [Esc] per uscire dalla modalità chat.",
     "alphakey-mode-warning-first-line": u"Puoi utilizzare temporaneamente i vecchi comandi di mpv con i tasti a-z.",
     "alphakey-mode-warning-second-line": u"Premi [TAB] per ritornare alla modalità chat di Syncplay.",
 
     "help-label" : u"Aiuto",
-    "reset-label" : u"Impostazioni iniziali",
+    "reset-label" : u"Elimina configurazione",
     "run-label" : u"Avvia Syncplay",
     "storeandrun-label" : u"Salva la configurazione e avvia Syncplay",
 
@@ -366,23 +365,23 @@ it = {
     "slowondesync-tooltip" : u"Riduce temporaneamente la velocità di riproduzione quando c'è bisogno di sincronizzarti con gli altri utenti. Non supportato su MPC-HC/BE.",
     "dontslowdownwithme-tooltip" : u"Gli altri utenti non vengono rallentati se non sei sincronizzato. Utile per i gestori della stanza.",
     "pauseonleave-tooltip" : u"Mette in pausa la riproduzione se vieni disconnesso o se qualcuno lascia la stanza.",
-    "readyatstart-tooltip" : u"Imposta il tuo stato su 'pronto' all'avvio (in caso contrario, sarai su 'non pronto' finché non cambierai il tuo stato)",
+    "readyatstart-tooltip" : u"Imposta il tuo stato su \"pronto\" all'avvio (in caso contrario, sarai su \"non pronto\" finché non cambierai il tuo stato)",
     "forceguiprompt-tooltip" : u"La finestra di configurazione non viene mostrata quando apri Syncplay.",
     "nostore-tooltip" : u"Avvia Syncplay con la configurazione scelta, ma non salva le impostazioni.",
     "rewindondesync-tooltip" : u"Torna indietro quando necessario per ristabilire la sincronizzazione. Disabilitare quest'opzione può causare gravi problemi di sincronizzazione!",
-    "fastforwardondesync-tooltip" : u"Avanza rapidamente quando non sei sincronizzato col gestore della stanza (o la tua posizione supposta se 'Non rallentare o riavvolgere gli altri utenti' è abilitato).",
-    "showosd-tooltip" : u"Invia i messaggi di Syncplay all'OSD del media player.",
+    "fastforwardondesync-tooltip" : u"Avanza rapidamente quando non sei sincronizzato col gestore della stanza (usa una posizione fittizia se 'Non rallentare o riavvolgere gli altri utenti' è abilitato).",
+    "showosd-tooltip" : u"Invia i messaggi di Syncplay al media player tramite OSD.",
     "showosdwarnings-tooltip" : u"Mostra gli avvisi in caso di riproduzione di un file differente, se sei l'unico utente nella stanza, se ci sono utenti non pronti, ecc.",
     "showsameroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alla stanza in cui si trova l'utente.",
     "shownoncontrollerosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi ai non operatori presenti nelle stanze gestite.",
     "showdifferentroomosd-tooltip" : u"Mostra le notifiche OSD per gli eventi relativi alle stanze in cui l'utente non si trova.",
     "showslowdownosd-tooltip" : u"Mostra le notifiche di rallentamento / riavvolgimento in caso di differenza temporale.",
-    "showdurationnotification-tooltip" : u"Utile quando manca un segmento di un file multiparte. Può causare dei falsi positivi.",
+    "showdurationnotification-tooltip" : u"Utile quando manca un segmento di un file con più parti. Può causare dei falsi positivi.",
     "language-tooltip" : u"Lingua da utilizzare in Syncplay.",
-    "unpause-always-tooltip" : u"Se riprendi la riproduzione, il tuo stato cambia in 'pronto' e la riproduzione viene avviata, piuttosto che impostarti solo su pronto.",
-    "unpause-ifalreadyready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', verrai impostato su pronto - ripeti il comando ancora una volta per avviare la riproduzione.",
-    "unpause-ifothersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto' la riproduzione verrà avviata solo se gli altri sono pronti.",
-    "unpause-ifminusersready-tooltip" : u"Se riprendi la riproduzione quando non sei 'pronto', la riproduzione verrà avviata solo se un numero minimo di utenti è 'pronto'.",
+    "unpause-always-tooltip" : u"Se riprendi la riproduzione, il tuo stato cambia in \"pronto\" e la riproduzione viene avviata, piuttosto che impostarti solo su pronto.",
+    "unpause-ifalreadyready-tooltip" : u"Se riprendi la riproduzione quando non sei \"pronto\", verrai impostato su pronto - ripeti il comando ancora una volta per avviare la riproduzione.",
+    "unpause-ifothersready-tooltip" : u"Se riprendi la riproduzione quando non sei \"pronto\" la riproduzione verrà avviata solo se gli altri sono pronti.",
+    "unpause-ifminusersready-tooltip" : u"Se riprendi la riproduzione quando non sei \"pronto\", la riproduzione verrà avviata solo se un numero minimo di utenti è \"pronto\".",
     "trusteddomains-arguments-tooltip" : u"Domini verso cui è possibile collegarsi automaticamente quando le playlist condivise sono abilitate.",
 
     "chatinputenabled-tooltip" : u"Abilita l'input della chat in mpv (premi Invio per chattare, per inviare ed Esc per cancellare)",
@@ -401,14 +400,14 @@ it = {
     "chatoutputmode-chatroom-tooltip": u"Mostra i nuovi messaggi di chat al di sotto di quelli precedenti.",
     "chatoutputmode-scrolling-tooltip": u"Scorri il testo della chat da destra a sinistra.",
 
-    "help-tooltip" : u"Apri la guida utente su Syncplay.pl.",
-    "reset-tooltip" : u"Ripristina tutte le impostazioni.",
+    "help-tooltip" : u"Apri la guida utente su syncplay.pl.",
+    "reset-tooltip" : u"Ripristina le impostazioni iniziali di Syncplay.",
     "update-server-list-tooltip" : u"Scarica la lista dei server pubblici da syncplay.pl.",
 
-    "joinroom-tooltip" : u"Abbandona la stanza attuale e entra in quella specificata.",
+    "joinroom-tooltip" : u"Lascia la stanza attuale e entra in quella specificata.",
     "seektime-msgbox-label" : u"Salta all'istante di tempo specificato (in secondi / min:sec). Usa +/- per una ricerca relativa.",
     "ready-tooltip" : u"Indica quando sei pronto a guardare.",
-    "autoplay-tooltip" : u"Riproduzione automatica quando il numero minimo di utenti è 'pronto'.",
+    "autoplay-tooltip" : u"Avvia la riproduzione automatica quando il numero minimo di utenti è pronto.",
     "switch-to-file-tooltip" : u"Doppio click per passare a {}", # Filename
     "sendmessage-tooltip" : u"Invia il messaggio alla stanza",
 
@@ -424,7 +423,7 @@ it = {
     # Server notifications
     "welcome-server-notification" : u"Benvenuto nel server Syncplay, ver. {0}",  # version
     "client-connected-room-server-notification" : u"{0}({2}) connesso alla stanza '{1}'",  # username, host, room
-    "client-left-server-notification" : u"{0} ha abbandonato il server",  # name
+    "client-left-server-notification" : u"{0} ha lasciato il server",  # name
     "no-salt-notification" : u"NOTA BENE: In futuro, per consentire il corretto funzionamento delle password generate da questo server (per le stanze gestite), aggiungi da linea di comando il seguente argomento prima di avviare il server Syncplay: --salt {}", #Salt
 
 
@@ -435,7 +434,7 @@ it = {
     "server-password-argument" : u'password del server',
     "server-isolate-room-argument" : u'Mantiene le stanze isolate',
     "server-salt-argument" : u"usare stringhe casuali per generare le password delle stanze gestite",
-    "server-disable-ready-argument" : u"disabilita la funzionalità 'pronto'",
+    "server-disable-ready-argument" : u"disabilita la funzionalità \"pronto\"",
     "server-motd-argument": u"percorso del file da cui verrà letto il messaggio del giorno",
     "server-chat-argument" : u"abilita o disabilita la chat",
     "server-chat-maxchars-argument" : u"Numero massimo di caratteri in un messaggio di chat (default è {})", # Default number of characters
@@ -445,12 +444,12 @@ it = {
     # Server errors
     "unknown-command-server-error" : u"Comando non riconosciuto {}",  # message
     "not-json-server-error" : u"Non è una stringa in codifica JSON {}",  # message
-    "not-known-server-error" : u"Devi essere riconosciuto dal server prima di poter inviare questo comando",
+    "not-known-server-error" : u"Devi essere autenticato dal server prima di poter inviare questo comando",
     "client-drop-server-error" : u"Il client è caduto: {} -- {}",  # host, error
     "password-required-server-error" : u"È richiesta una password",
     "wrong-password-server-error" : u"La password inserita è errata",
-    "hello-server-error" : u"Non ci sono abbastanza argomenti Hello",
-
+    "hello-server-error" : "Not enough Hello arguments", #DO NOT TRANSLATE
+    
     # Playlists
     "playlist-selection-changed-notification" : u"{} ha cambiato il file selezionato nella playlist", # Username
     "playlist-contents-changed-notification" : u"{} ha aggiornato la playlist", # Username

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -254,6 +254,7 @@ ru = {
     "chat-top-option": u"Top",  # TODO: Translate
     "chat-middle-option": u"Middle",  # TODO: Translate
     "chat-bottom-option": u"Bottom",  # TODO: Translate
+    "chatoutputheader-label" : u"Chat message output", # TODO: Traslate
     "chatoutputfont-label": u"Chat output font", # TODO: Translate
     "chatoutputenabled-label": u"Enable chat output in media player (mpv only for now)", # TODO: Translate
     "chatoutputposition-label": u"Output mode", # TODO: Translate
@@ -313,7 +314,7 @@ ru = {
     "help-menu-label" : u"&Помощь",
     "userguide-menu-label" : u"&Руководство пользователя",
     "update-menu-label" : u"Проверить &обновления",
-    
+
     #About dialog - TODO: Translate
     "about-menu-label": u"&About Syncplay",
     "about-dialog-title": u"About Syncplay",

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -257,7 +257,7 @@ class ConfigDialog(QtWidgets.QDialog):
                 # executable.  I would have used plistlib here, but since the version of this library in
                 # py < 3.4 can't read from binary plist files it's pretty much useless.  Therefore, let's
                 # play a game of "Guess my executable!"
-                
+
                 # Step 1: get all the executable files.  In a Mac OS X Application bundle, executables are stored
                 # inside <bundle root>/Contents/MacOS.
                 execPath = os.path.join(os.path.normpath(fileName), 'Contents', 'MacOS')
@@ -266,7 +266,7 @@ class ConfigDialog(QtWidgets.QDialog):
                     fn = os.path.join(execPath, fn)
                     if os.path.isfile(fn) and os.access(fn, os.X_OK):
                         execFiles.append(fn)
-                
+
                 # Step 2: figure out which file name looks like the application name
                 baseAppName = os.path.basename(fileName).replace('.app', '').lower()
                 foundExe = False
@@ -276,14 +276,14 @@ class ConfigDialog(QtWidgets.QDialog):
                         fileName = fn
                         foundExe = True
                         break
-                
+
                 # Step 3: use the first executable in the list if no executable was found
                 try:
                     if not foundExe:
                       fileName = execFiles[0]
                 except IndexError:  # whoops, looks like this .app doesn't contain a executable file at all
                     pass
-                
+
             self.executablepathCombobox.setEditText(os.path.normpath(fileName))
 
     def loadLastUpdateCheckDate(self):
@@ -379,7 +379,7 @@ class ConfigDialog(QtWidgets.QDialog):
             elif os.path.isdir(QStandardPaths.standardLocations(QStandardPaths.HomeLocation)[0]):
                 defaultdirectory = QStandardPaths.standardLocations(QStandardPaths.HomeLocation)[0]
             else:
-                defaultdirectory = ""        
+                defaultdirectory = ""
         browserfilter = "All files (*)"
         fileName, filtr = QtWidgets.QFileDialog.getOpenFileName(self, "Browse for media files", defaultdirectory,
                 browserfilter, "", options)
@@ -387,10 +387,10 @@ class ConfigDialog(QtWidgets.QDialog):
             self.mediapathTextbox.setText(os.path.normpath(fileName))
             self.mediadirectory = os.path.dirname(fileName)
             self.saveMediaBrowseSettings()
-    
+
     def _runWithoutStoringConfig(self):
         self._saveDataAndLeave(False)
-    
+
     def _saveDataAndLeave(self, storeConfiguration=True):
         self.config['noStore'] = not storeConfiguration
         if storeConfiguration:
@@ -946,7 +946,7 @@ class ConfigDialog(QtWidgets.QDialog):
                                              self.chatInputFontButton.objectName(), self.chatFontLabel.objectName(),
                                              self.chatInputColourButton.objectName(), self.chatDirectInputCheckbox.objectName()]
         # Output
-        self.chatOutputGroup = QtWidgets.QGroupBox(u"Chat message output")
+        self.chatOutputGroup = QtWidgets.QGroupBox(getMessage("chatoutputheader-label"))
         self.chatOutputLayout = QtWidgets.QGridLayout()
         self.chatLayout.addWidget(self.chatOutputGroup)
         self.chatOutputGroup.setLayout(self.chatOutputLayout)
@@ -1213,7 +1213,7 @@ class ConfigDialog(QtWidgets.QDialog):
             settings = QSettings("Syncplay", "MoreSettings")
             settings.clear()
         self.datacleared = True
-    
+
     def populateEmptyServerList(self):
         if self.publicServers is None:
             if self.config["checkForUpdatesAutomatically"] == True:
@@ -1241,7 +1241,7 @@ class ConfigDialog(QtWidgets.QDialog):
             self.serverpassTextbox.setEnabled(True)
             self.serverpassTextbox.setReadOnly(False)
             self.serverpassTextbox.setText(self.storedPassword)
-        
+
     def __init__(self, config, playerpaths, error, defaultConfig):
         self.config = config
         self.defaultConfig = defaultConfig

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -993,7 +993,7 @@ class MainWindow(QtWidgets.QMainWindow):
         MediaDirectoriesDialog = QtWidgets.QDialog()
         MediaDirectoriesDialog.setWindowTitle(getMessage("syncplay-mediasearchdirectories-title")) # TODO: Move to messages_*.py
         MediaDirectoriesLayout = QtWidgets.QGridLayout()
-        MediaDirectoriesLabel = QtWidgets.QLabel(getMessage("syncplay-mediasearchdirectories-title"))
+        MediaDirectoriesLabel = QtWidgets.QLabel(getMessage("syncplay-mediasearchdirectories-label"))
         MediaDirectoriesLayout.addWidget(MediaDirectoriesLabel, 0, 0, 1, 2)
         MediaDirectoriesTextbox = QtWidgets.QPlainTextEdit()
         MediaDirectoriesTextbox.setLineWrapMode(QtWidgets.QPlainTextEdit.NoWrap)


### PR DESCRIPTION
The entire application and its installer have been translated into Italian.

A hard coded label in **_ui/GuiConfiguration.py_** has been replaced by a new label `chatoutputheader-label`. Thus, `self.chatOutputGroup = QtWidgets.QGroupBox(u"Chat message output")` is now `self.chatOutputGroup = QtWidgets.QGroupBox(getMessage("chatoutputheader-label"))`.

For clarity's sake, `chatoutputheader-label` has also been added to the others **messages_xx.py**