### PR TITLE
Fixing some unicode and Italian translation issues

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1929,6 +1929,7 @@ class FileSwitchManager(object):
             return False
 
     def notifyUserIfFileNotInMediaDirectory(self, filenameToFind, path):
+        path = path.decode('utf-8')
         directoryToFind = os.path.dirname(path)
         if directoryToFind in self.mediaDirectoriesNotFound:
             return

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1929,7 +1929,10 @@ class FileSwitchManager(object):
             return False
 
     def notifyUserIfFileNotInMediaDirectory(self, filenameToFind, path):
-        path = path.decode('utf-8')
+        try:
+            path = path.decode('utf-8')
+        except UnicodeEncodeError:
+            pass
         directoryToFind = os.path.dirname(path)
         if directoryToFind in self.mediaDirectoriesNotFound:
             return

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -50,7 +50,7 @@ it = {
 
     "file-different-notification" : u"Il file che stai riproducendo sembra essere diverso da quello di {}",  # User
     "file-differences-notification" : u"Il tuo file mostra le seguenti differenze: {}", # Differences
-    "room-file-differences" : u"Differenze: {} \n", # File differences (filename, size, and/or duration)
+    "room-file-differences" : u"Differenze: {}", # File differences (filename, size, and/or duration)
     "file-difference-filename" : u"nome",
     "file-difference-filesize" : u"dimensione",
     "file-difference-duration" : u"durata",

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -19,6 +19,7 @@ from twisted.internet import task
 from syncplay.ui.consoleUI import ConsoleUI
 if isMacOS() and IsPySide:
     from Foundation import NSURL
+    from Cocoa import NSString, NSUTF8StringEncoding
 lastCheckedForUpdates = None
 
 class ConsoleInGUI(ConsoleUI):
@@ -1609,7 +1610,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if urls and urls[0].scheme() == 'file':
             url = event.mimeData().urls()[0]
             if isMacOS() and IsPySide:
-                dropfilepath = os.path.abspath(NSURL.URLWithString_(str(url.toString())).filePathURL().path())
+                macURL = NSString.alloc().initWithString_(unicode(url.toString()))
+                pathString = macURL.stringByAddingPercentEscapesUsingEncoding_(NSUTF8StringEncoding)
+                dropfilepath = os.path.abspath(NSURL.URLWithString_(pathString).filePathURL().path())
             else:
                 dropfilepath = os.path.abspath(unicode(url.toLocalFile()))
             if rewindFile == False:

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -223,7 +223,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
                 for url in urls[::-1]:
                     if isMacOS() and IsPySide:
-                        dropfilepath = os.path.abspath(NSURL.URLWithString_(str(url.toString())).filePathURL().path())
+                        macURL = NSString.alloc().initWithString_(unicode(url.toString()))
+                        pathString = macURL.stringByAddingPercentEscapesUsingEncoding_(NSUTF8StringEncoding)
+                        dropfilepath = os.path.abspath(NSURL.URLWithString_(pathString).filePathURL().path())
                     else:
                         dropfilepath = os.path.abspath(unicode(url.toLocalFile()))                    
                     if os.path.isfile(dropfilepath):
@@ -328,7 +330,9 @@ class MainWindow(QtWidgets.QMainWindow):
                     indexRow = window.playlist.count()
                 for url in urls[::-1]:
                     if isMacOS() and IsPySide:
-                        dropfilepath = os.path.abspath(NSURL.URLWithString_(str(url.toString())).filePathURL().path())
+                        macURL = NSString.alloc().initWithString_(unicode(url.toString()))
+                        pathString = macURL.stringByAddingPercentEscapesUsingEncoding_(NSUTF8StringEncoding)
+                        dropfilepath = os.path.abspath(NSURL.URLWithString_(pathString).filePathURL().path())
                     else:
                         dropfilepath = os.path.abspath(unicode(url.toLocalFile())) 
                     if os.path.isfile(dropfilepath):


### PR DESCRIPTION
I am experimenting with files with non-ASCII characters in their name or path, and I have found some issues in the current version. In the following, there is a detailed list of what I found so far and how I fixed it. I am using this PR to keep track of these bugs and changes, since I am currently in the process of finding and debugging some of them.

Unicode support
- [x] file properties (name, size, duration) are not loaded if filepath contains non-ASCII characters.
- [x] (macOS) drag-and-drop of files with non-ASCII characters in their name does not open the file.
- [x] (macOS) drag-and-drop of files with non-ASCII characters on the shared playlist does not load the file.
- [ ] (VLC) "file differences: name" is initially triggered when a file with non-ASCII characters in its name is opened from VLC, then the player drops this difference, but the OSD does not update. (These may be more bugs, actually).

Italian translation
- [x] (VLC) Readiness status is not shown in the OSD if there are any file differences. 

 