### PR TITLE
Remove obsolete encode/decode calls

### DIFF
--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -972,12 +972,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.updatingPlaylist = True
             for URI in URIsToAdd:
                 URI = URI.rstrip()
-                try:
-                    URI = URI.encode('utf-8')
-                except UnicodeDecodeError:
-                    pass
                 URI = urllib.parse.unquote(URI)
-                URI = URI.decode('utf-8')
                 if URI != "":
                     self.addStreamToPlaylist(URI)
             self.updatingPlaylist = False


### PR DESCRIPTION
This fixes the following error I'm seeing when I try to add URIs to the playlist on the current master version:

```
Traceback (most recent call last):
  File "/home/user/Projects/syncplay/syncplay/ui/gui.py", line 628, in <lambda>
    menu.addAction(QtGui.QPixmap(resourcespath + "world_add.png"), getMessage("addurlstoplaylist-menu-label"), lambda: self.OpenAddURIsToPlaylistDialog())
  File "/home/user/Projects/syncplay/syncplay/ui/gui.py", line 382, in wrapper
    return f(self, *args, **kwds)
  File "/home/user/Projects/syncplay/syncplay/ui/gui.py", line 979, in OpenAddURIsToPlaylistDialog
    URI = urllib.parse.unquote(URI)
  File "/usr/lib64/python3.6/urllib/parse.py", line 610, in unquote
    if '%' not in string:
TypeError: a bytes-like object is required, not 'str'
```