### PR TITLE
Create XDG_CONFIG_HOME with safe permissions

### DIFF
--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -352,7 +352,7 @@ class ConfigurationGetter(object):
     def _getXdgConfigHome(self):
         path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
         if not os.path.isdir(path):
-            os.mkdir(path, 0o755)
+            os.mkdir(path, 0o700)
         return path
 
     def _parseConfigFile(self, iniPath, createConfig=True):


### PR DESCRIPTION
Turns out I committed a slight standards compliance blunder in my XDG patch:

> If, when attempting to write a file, the destination directory is non-existant an attempt should be made to create it with permission 0700.

As per the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).