### PR TITLE
add-environment-support

### DIFF
--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -615,11 +615,11 @@ class ConfigurationGetter(object):
             description=getMessage("server-argument-description"),
             epilog=getMessage("server-argument-epilog"))
         self._argparser.add_argument('--port', metavar='port', type=str, nargs='?', help=getMessage("server-port-argument"))
-        self._argparser.add_argument('--password', metavar='password', type=str, nargs='?', help=getMessage("server-password-argument"))
+        self._argparser.add_argument('--password', metavar='password', type=str, nargs='?', help=getMessage("server-password-argument"), default=os.environ.get('SYNCPLAY_PASSWORD'))
         self._argparser.add_argument('--isolate-rooms', action='store_true', help=getMessage("server-isolate-room-argument"))
         self._argparser.add_argument('--disable-ready', action='store_true', help=getMessage("server-disable-ready-argument"))
         self._argparser.add_argument('--disable-chat', action='store_true', help=getMessage("server-chat-argument"))
-        self._argparser.add_argument('--salt', metavar='salt', type=str, nargs='?', help=getMessage("server-salt-argument"))
+        self._argparser.add_argument('--salt', metavar='salt', type=str, nargs='?', help=getMessage("server-salt-argument"), default=os.environ.get('SYNCPLAY_SALT'))
         self._argparser.add_argument('--motd-file', metavar='file', type=str, nargs='?', help=getMessage("server-motd-argument"))
         self._argparser.add_argument('--max-chat-message-length', metavar='maxChatMessageLength', type=int, nargs='?', help=getMessage("server-chat-maxchars-argument").format(constants.MAX_CHAT_MESSAGE_LENGTH))
         self._argparser.add_argument('--max-username-length', metavar='maxUsernameLength', type=int, nargs='?', help=getMessage("server-maxusernamelength-argument").format(constants.MAX_USERNAME_LENGTH))


### PR DESCRIPTION
For --password and --salt we now check the environment for the corresponding
variables SYNCPLAY_PASSWORD and SYNCPLAY_SALT. If they are found their values
are used as long as the options are not given via CLI.

Setting both options this way is highly encouraged. It fixes leaking these
secret options to other system users (e.g. on Linux everybody can see them
with 'ps' or looking at '/proc/<pid>/cmdline'.