### PR TITLE
IPv6 support

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -783,8 +783,8 @@ info = dict(
         'py2exe': {
             'dist_dir': OUT_DIR,
             'packages': 'PySide2',
-            'includes': 'twisted, sys, encodings, datetime, os, time, math, liburl, ast, unicodedata, _ssl, win32pipe',
-            'excludes': 'venv, doctest, pdb, unittest, win32clipboard, win32file, win32pdh, win32security, win32trace, win32ui, winxpgui, win32process, Tkinter',
+            'includes': 'twisted, sys, encodings, datetime, os, time, math, liburl, ast, unicodedata, _ssl, win32pipe, win32file',
+            'excludes': 'venv, doctest, pdb, unittest, win32clipboard, win32pdh, win32security, win32trace, win32ui, winxpgui, win32process, Tkinter',
             'dll_excludes': 'msvcr71.dll, MSVCP90.dll, POWRPROF.dll',
             'optimize': 2,
             'compressed': 1

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -783,8 +783,8 @@ info = dict(
         'py2exe': {
             'dist_dir': OUT_DIR,
             'packages': 'PySide2',
-            'includes': 'twisted, sys, encodings, datetime, os, time, math, liburl, ast, unicodedata, _ssl',
-            'excludes': 'venv, doctest, pdb, unittest, win32clipboard, win32file, win32pdh, win32security, win32trace, win32ui, winxpgui, win32pipe, win32process, Tkinter',
+            'includes': 'twisted, sys, encodings, datetime, os, time, math, liburl, ast, unicodedata, _ssl, win32pipe',
+            'excludes': 'venv, doctest, pdb, unittest, win32clipboard, win32file, win32pdh, win32security, win32trace, win32ui, winxpgui, win32process, Tkinter',
             'dll_excludes': 'msvcr71.dll, MSVCP90.dll, POWRPROF.dll',
             'optimize': 2,
             'compressed': 1

--- a/syncplay/__init__.py
+++ b/syncplay/__init__.py
@@ -1,5 +1,5 @@
-version = '1.6.2'
-revision = ''
+version = '1.6.3'
+revision = ' beta'
 milestone = 'Yoitsu'
-release_number = '71'
+release_number = '72'
 projectURL = 'https://syncplay.pl/'

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -11,6 +11,7 @@ import time
 from copy import deepcopy
 from functools import wraps
 
+from twisted.internet.endpoints import HostnameEndpoint
 from twisted.internet.protocol import ClientFactory
 from twisted.internet import reactor, task, defer, threads
 
@@ -728,7 +729,8 @@ class SyncplayClient(object):
         if '[' in host:
             host = host.strip('[]')
         port = int(port)
-        reactor.connectTCP(host, port, self.protocolFactory)
+        self._endpoint = HostnameEndpoint(reactor, host, port)
+        self._endpoint.connect(self.protocolFactory)
         reactor.run()
 
     def stop(self, promptForAction=False):

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -11,6 +11,7 @@ import time
 from copy import deepcopy
 from functools import wraps
 
+from twisted.internet.endpoints import HostnameEndpoint
 from twisted.internet.protocol import ClientFactory
 from twisted.internet import reactor, task, defer, threads
 
@@ -726,7 +727,8 @@ class SyncplayClient(object):
             self._playerClass = None
         self.protocolFactory = SyncClientFactory(self)
         port = int(port)
-        reactor.connectTCP(host, port, self.protocolFactory)
+        self._endpoint = HostnameEndpoint(reactor, host, port)
+        self._endpoint.connect(self.protocolFactory)
         reactor.run()
 
     def stop(self, promptForAction=False):

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -11,7 +11,6 @@ import time
 from copy import deepcopy
 from functools import wraps
 
-from twisted.internet.endpoints import HostnameEndpoint
 from twisted.internet.protocol import ClientFactory
 from twisted.internet import reactor, task, defer, threads
 
@@ -726,9 +725,10 @@ class SyncplayClient(object):
             reactor.callLater(0.1, self._playerClass.run, self, self._config['playerPath'], self._config['file'], self._config['playerArgs'], )
             self._playerClass = None
         self.protocolFactory = SyncClientFactory(self)
+        if '[' in host:
+            host = host.strip('[]')
         port = int(port)
-        self._endpoint = HostnameEndpoint(reactor, host, port)
-        self._endpoint.connect(self.protocolFactory)
+        reactor.connectTCP(host, port, self.protocolFactory)
         reactor.run()
 
     def stop(self, promptForAction=False):

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -313,7 +313,9 @@ class ConfigurationGetter(object):
         port = constants.DEFAULT_PORT if not self._config["port"] else self._config["port"]
         if host:
             if ':' in host:
-                host, port = host.split(':', 1)
+                host, port = host.rsplit(':', 1)
+                if '[' in host:
+                    host = host.strip('[]')
                 try:
                     port = int(port)
                 except ValueError:

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -313,16 +313,32 @@ class ConfigurationGetter(object):
         port = constants.DEFAULT_PORT if not self._config["port"] else self._config["port"]
         if host:
             if ':' in host:
-                host, port = host.rsplit(':', 1)
-                if '[' in host:
-                    host = host.strip('[]')
-                try:
-                    port = int(port)
-                except ValueError:
+                if host.count(':') == 1:
+                    #IPv4 address or hostname, with port
+                    host, port = host.rsplit(':', 1)
                     try:
-                        port = port.encode('ascii', 'ignore')
-                    except:
-                        port = ""
+                        port = int(port)
+                    except ValueError:
+                        try:
+                            port = port.encode('ascii', 'ignore')
+                        except:
+                            port = ""
+                else:
+                    #IPv6 address
+                    if ']' in host:
+                        #IPv6 address in brackets
+                        endBracket = host.index(']')
+                        try:
+                            #port explicitely indicated
+                            port = int(host[endBracket+2:])
+                        except ValueError:
+                            #no port after the bracket
+                            pass
+                        host = host[:endBracket+1]
+                    else:
+                        #IPv6 address with no port and no brackets
+                        #add brackets to correctly store IPv6 addresses in configs
+                        host = '[' + host + ']'
         return host, port
 
     def _checkForPortableFile(self):

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -556,7 +556,7 @@ class ConfigDialog(QtWidgets.QDialog):
             self.error = error
         if config['host'] is None:
             host = ""
-        elif ":" in config['host']:
+        elif ":" in config['host'] and '[' not in config['host']:
             host = config['host']
         else:
             host = config['host'] + ":" + str(config['port'])
@@ -580,7 +580,7 @@ class ConfigDialog(QtWidgets.QDialog):
                 i += 1
         self.hostCombobox.setEditable(True)
         self.hostCombobox.setEditText(host)
-        self.hostCombobox.setFixedWidth(165)
+        self.hostCombobox.setFixedWidth(250)
         self.hostLabel = QLabel(getMessage("host-label"), self)
         self.findServerButton = QtWidgets.QPushButton(QtGui.QIcon(resourcespath + 'arrow_refresh.png'), getMessage("update-server-list-label"))
         self.findServerButton.clicked.connect(self.updateServerList)
@@ -634,7 +634,7 @@ class ConfigDialog(QtWidgets.QDialog):
         self.executablepathCombobox.setEditable(True)
         self.executablepathCombobox.currentIndexChanged.connect(self.updateExecutableIcon)
         self.executablepathCombobox.setEditText(self._tryToFillPlayerPath(config['playerPath'], playerpaths))
-        self.executablepathCombobox.setFixedWidth(250)
+        self.executablepathCombobox.setFixedWidth(330)
         self.executablepathCombobox.editTextChanged.connect(self.updateExecutableIcon)
 
         self.executablepathLabel = QLabel(getMessage("executable-path-label"), self)

--- a/syncplayServer.py
+++ b/syncplayServer.py
@@ -24,7 +24,10 @@ class DualStackPort(tcp.Port):
 
     def createInternetSocket(self):
         s = tcp.Port.createInternetSocket(self)
-        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        try:
+            s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        except:
+            pass
         return s
 
 if __name__ == '__main__':

--- a/syncplayServer.py
+++ b/syncplayServer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #coding:utf8
 
+import socket
 import sys
 
 # libpath
@@ -12,16 +13,24 @@ except AttributeError:
     import warnings
     warnings.warn("You must run Syncplay with Python 3.4 or newer!")
 
-from twisted.internet.endpoints import TCP6ServerEndpoint
-from twisted.internet import reactor
+from twisted.internet import reactor, tcp
 
 from syncplay.server import SyncFactory, ConfigurationGetter
+
+class DualStackPort(tcp.Port):
+
+    def __init__(self, port, factory, backlog=50, interface='', reactor=None):
+        tcp.Port.__init__(self, port, factory, backlog, interface, reactor)
+
+    def createInternetSocket(self):
+        s = tcp.Port.createInternetSocket(self)
+        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        return s
 
 if __name__ == '__main__':
     argsGetter = ConfigurationGetter()
     args = argsGetter.getConfiguration()
-    endpoint = TCP6ServerEndpoint(reactor, int(args.port))
-    endpoint.listen(
+    dsp = DualStackPort(int(args.port),
         SyncFactory(
             args.port,
             args.password,
@@ -32,5 +41,7 @@ if __name__ == '__main__':
             args.disable_chat,
             args.max_chat_message_length,
             args.max_username_length,
-            args.stats_db_file))
+            args.stats_db_file),
+        interface='::')
+    dsp.startListening()
     reactor.run()

--- a/syncplayServer.py
+++ b/syncplayServer.py
@@ -12,6 +12,7 @@ except AttributeError:
     import warnings
     warnings.warn("You must run Syncplay with Python 3.4 or newer!")
 
+from twisted.internet.endpoints import TCP6ServerEndpoint
 from twisted.internet import reactor
 
 from syncplay.server import SyncFactory, ConfigurationGetter
@@ -19,8 +20,8 @@ from syncplay.server import SyncFactory, ConfigurationGetter
 if __name__ == '__main__':
     argsGetter = ConfigurationGetter()
     args = argsGetter.getConfiguration()
-    reactor.listenTCP(
-        int(args.port),
+    endpoint = TCP6ServerEndpoint(reactor, int(args.port))
+    endpoint.listen(
         SyncFactory(
             args.port,
             args.password,


### PR DESCRIPTION
Introduces the support for IPv6 in Syncplay (addressing issue #107).

The server now listens on both IPv4 and IPv6 protocols, if possible. The client should be able to connect to a server using both protocols. The user interfaces of the client (CLI and GUI) were updated to accept and parse correctly the standard notation for IPv6 address + port number  (e.g. `[2001:db8::1]:8080`).  