### PR TITLE
Remove NOTICE tag for clientversion messages

### DIFF
--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -433,7 +433,7 @@ de = {
     "nofile-note": "(keine Datei wird abgespielt)",
 
     # Server messages to client
-    "new-syncplay-available-motd-message": "<NOTICE> Du nutzt Syncplay Version {}, aber es gibt eine neuere Version auf https://syncplay.pl</NOTICE>",  # ClientVersion
+    "new-syncplay-available-motd-message": "Du nutzt Syncplay Version {}, aber es gibt eine neuere Version auf https://syncplay.pl",  # ClientVersion
 
     # Server notifications
     "welcome-server-notification": "Willkommen zum Syncplay-Server, v. {0}",  # version

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -432,7 +432,7 @@ en = {
     "nofile-note": "(No file being played)",
 
     # Server messages to client
-    "new-syncplay-available-motd-message": "<NOTICE> You are using Syncplay {} but a newer version is available from https://syncplay.pl </NOTICE>",  # ClientVersion
+    "new-syncplay-available-motd-message": "You are using Syncplay {} but a newer version is available from https://syncplay.pl",  # ClientVersion
 
     # Server notifications
     "welcome-server-notification": "Welcome to Syncplay server, ver. {0}",  # version

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -432,7 +432,7 @@ it = {
     "nofile-note": "(Nessun file in riproduzione)",
 
     # Server messages to client
-    "new-syncplay-available-motd-message": "<NOTICE> Stai usando Syncplay {} ma una nuova versione è disponibile presso https://syncplay.pl </NOTICE>",  # ClientVersion
+    "new-syncplay-available-motd-message": "Stai usando Syncplay {} ma una nuova versione è disponibile presso https://syncplay.pl",  # ClientVersion
 
     # Server notifications
     "welcome-server-notification": "Benvenuto nel server Syncplay, ver. {0}",  # version

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -434,7 +434,7 @@ ru = {
     "nofile-note": "(ничего)",
 
     # Server messages to client
-    "new-syncplay-available-motd-message": "<NOTICE> Вы используете Syncplay версии {}. Доступна более новая версия на https://syncplay.pl/ . </NOTICE>",  # ClientVersion
+    "new-syncplay-available-motd-message": "Вы используете Syncplay версии {}. Доступна более новая версия на https://syncplay.pl/",  # ClientVersion
 
     # Server notifications
     "welcome-server-notification": "Добро пожаловать на сервер Syncplay версии {0}",  # version


### PR DESCRIPTION
Including this "tag" on any message, causes the client to strip multi-line messages received from server, basically only printing the first line. You can't for example see the server MOTD and a clientversion message at the same time (it only shows up the latter, not both). Client prints that <NOTICE> tag as it if were a nickname, so it makes sense to strip multi-line messages.