### PR TITLE
Workaround for older twisted versions which don't support raiseMinimumTo.

### DIFF
--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -230,7 +230,7 @@ class SyncFactory(Factory):
                 contextFactory = ssl.CertificateOptions(privateKey=privKeyPySSL, certificate=certifPySSL,
                                                         extraCertChain=chainPySSL, acceptableCiphers=accCiphers,
                                                         raiseMinimumTo=ssl.TLSVersion.TLSv1_2)
-            except:
+            except AttributeError:
                 contextFactory = ssl.CertificateOptions(privateKey=privKeyPySSL, certificate=certifPySSL,
                                                         extraCertChain=chainPySSL, acceptableCiphers=accCiphers,
                                                         method=TLSv1_2_METHOD)

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -13,6 +13,7 @@ from twisted.internet.protocol import Factory
 try:
     from OpenSSL import crypto
     from twisted.internet import ssl
+    from OpenSSL.SSL import TLSv1_2_METHOD
 except:
     pass
 
@@ -225,9 +226,14 @@ class SyncFactory(Factory):
                                "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
             accCiphers = ssl.AcceptableCiphers.fromOpenSSLCipherString(cipherListString)
 
-            contextFactory = ssl.CertificateOptions(privateKey=privKeyPySSL, certificate=certifPySSL,
-                                                    extraCertChain=chainPySSL, acceptableCiphers=accCiphers,
-                                                    raiseMinimumTo=ssl.TLSVersion.TLSv1_2)
+            try:
+                contextFactory = ssl.CertificateOptions(privateKey=privKeyPySSL, certificate=certifPySSL,
+                                                        extraCertChain=chainPySSL, acceptableCiphers=accCiphers,
+                                                        raiseMinimumTo=ssl.TLSVersion.TLSv1_2)
+            except:
+                contextFactory = ssl.CertificateOptions(privateKey=privKeyPySSL, certificate=certifPySSL,
+                                                        extraCertChain=chainPySSL, acceptableCiphers=accCiphers,
+                                                        method=TLSv1_2_METHOD)
 
             self.options = contextFactory
             self.serverAcceptsTLS = True

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -12,8 +12,8 @@ from twisted.internet.protocol import Factory
 
 try:
     from OpenSSL import crypto
-    from twisted.internet import ssl
     from OpenSSL.SSL import TLSv1_2_METHOD
+    from twisted.internet import ssl
 except:
     pass
 


### PR DESCRIPTION
Twisted version 16.6.0 and older don't support raiseMinimumTo argument in CertificateOptions. This allows TLS to work on distributions like Debian Stretch (current stable) and Ubuntu 16.04 LTS.