### PR TITLE
Better TLS certificate chain support

### DIFF
--- a/syncplay/protocols.py
+++ b/syncplay/protocols.py
@@ -688,7 +688,7 @@ class SyncServerProtocol(JSONCommandProtocol):
         if "send" in inquiry:
             if not self.isLogged() and self._factory.serverAcceptsTLS:
                 lastEditCertTime = self._factory.checkLastEditCertTime()
-                if lastEditCertTime is not None and lastEditCertTime != self._factory.lastEditCertTime:
+                if lastEditCertTime and lastEditCertTime != self._factory.lastEditCertTime:
                     self._factory.updateTLSContextFactory()
                 if self._factory.options is not None:
                     self.sendTLS({"startTLS": "true"})


### PR DESCRIPTION
This PR adds support for `fullchain.pem` files, i.e., where the main/leaf server certificate is included in the chain file.
Additionally, `chain.pem` or `fullchain.pem` files with more than one intermediate certificate are now supported.

The PEM splitting function might look a bit hacky, but it should be perfectly safe and doesn't require any dependencies.

I've changed the last-edit-check to use the most recent timestamp out of all the four `.pem` files.

Hope this is useful! (it is for me ;))