### PR TITLE
Misspell: change "inteface" to "interface"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ certifi>=2018.11.29
 twisted[tls]>=16.4.0
 appnope>=0.1.0; sys_platform == 'darwin'
 pypiwin32>=223; sys_platform == 'win32'
-zope.inteface>=4.4.0; sys_platform == 'win32'
+zope.interface>=4.4.0; sys_platform == 'win32'


### PR DESCRIPTION
Changing "zope.inteface" to "zope.interface" for dependencies installation.
It's a misspell-problem when I try compiling the source code.