### PR TITLE
Use ca configuration if defined

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -129,6 +129,11 @@ class SyncplayClient(object):
 
         self._serverSupportsTLS = True
 
+        """Override certPath if defined in the configuration"""
+        if config['ca']:
+            certPath = config['ca']
+            os.environ['SSL_CERT_FILE'] = certPath
+
         if constants.LIST_RELATIVE_CONFIGS and 'loadedRelativePaths' in self._config and self._config['loadedRelativePaths']:
             paths = "; ".join(self._config['loadedRelativePaths'])
             self.ui.showMessage(getMessage("relative-config-notification").format(paths), noPlayer=True, noTimestamp=True)

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -92,7 +92,8 @@ class ConfigurationGetter(object):
             "notificationTimeout": 3,
             "alertTimeout": 5,
             "chatTimeout": 7,
-            "publicServers": []
+            "publicServers": [],
+            "ca": None
         }
 
         self._defaultConfig = self._config.copy()
@@ -191,7 +192,7 @@ class ConfigurationGetter(object):
                 "autoplayInitialState", "mediaSearchDirectories",
                 "sharedPlaylistEnabled", "loopAtEndOfPlaylist",
                 "loopSingleFiles",
-                "onlySwitchToTrustedDomains", "trustedDomains", "publicServers"],
+                "onlySwitchToTrustedDomains", "trustedDomains", "publicServers", "ca"],
             "gui": [
                 "showOSD", "showOSDWarnings", "showSlowdownOSD",
                 "showDifferentRoomOSD", "showSameRoomOSD",


### PR DESCRIPTION
It let the user push his own CA to syncplay by override certPath.

I saw that certifi.where() use his own cacert bundle, it can be usefull to use another one. It also fixed the second scenario of #248 when we use a self-signed certificate with a custom CA.

