### PR TITLE
Add error message if SAN doesn't match hostname

### DIFF
--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -320,6 +320,7 @@ de = {
     "startTLS-initiated": "Attempting secure connection",
     "startTLS-secure-connection-ok": "Secure connection established ({})",
     "startTLS-server-certificate-invalid": 'Secure connection failed. The server uses an invalid security certificate. This communication could be intercepted by a third party. For further details and troubleshooting see <a href="https://syncplay.pl/trouble">here</a>.',
+    "startTLS-server-certificate-invalid-DNS-ID": "Syncplay does not trust this server because it uses a certificate that is not valid for its hostname.",
     "startTLS-not-supported-client": "This client does not support TLS",
     "startTLS-not-supported-server": "This server does not support TLS",
 

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -1,4 +1,4 @@
-# coding:utf8
+startTLS-server-certificate-invalid-DNS-ID# coding:utf8
 
 """English dictionary"""
 
@@ -321,7 +321,7 @@ en = {
     "startTLS-initiated": "Attempting secure connection",
     "startTLS-secure-connection-ok": "Secure connection established ({})",
     "startTLS-server-certificate-invalid": 'Secure connection failed. The server uses an invalid security certificate. This communication could be intercepted by a third party. For further details and troubleshooting see <a href="https://syncplay.pl/trouble">here</a>.',
-    "startTLS-server-certificate-invalid-DNS-ID": "Secure connection failed. The Subject Alternative Name in certificate doesn't match the server hostname.",
+    "startTLS-server-certificate-invalid-DNS-ID": "Syncplay does not trust this server because it uses a certificate that is not valid for its hostname.",
     "startTLS-not-supported-client": "This client does not support TLS",
     "startTLS-not-supported-server": "This server does not support TLS",
 

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -321,6 +321,7 @@ en = {
     "startTLS-initiated": "Attempting secure connection",
     "startTLS-secure-connection-ok": "Secure connection established ({})",
     "startTLS-server-certificate-invalid": 'Secure connection failed. The server uses an invalid security certificate. This communication could be intercepted by a third party. For further details and troubleshooting see <a href="https://syncplay.pl/trouble">here</a>.',
+    "startTLS-server-certificate-invalid-DNS-ID": "Secure connection failed. The Subject Alternative Name in certificate doesn't match the server hostname.",
     "startTLS-not-supported-client": "This client does not support TLS",
     "startTLS-not-supported-server": "This server does not support TLS",
 

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -1,4 +1,4 @@
-startTLS-server-certificate-invalid-DNS-ID# coding:utf8
+# coding:utf8
 
 """English dictionary"""
 

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -321,6 +321,7 @@ es = {
     "startTLS-initiated": "Intentando conexión segura",
     "startTLS-secure-connection-ok": "Conexión segura establecida ({})",
     "startTLS-server-certificate-invalid": 'Falló la conexión segura. El servidor utiliza un certificado inválido. Esta comunicación podría ser interceptada por un tercero. Para más detalles y solución de problemas, consulta <a href="https://syncplay.pl/trouble">aquí</a>.',
+    "startTLS-server-certificate-invalid-DNS-ID": "Syncplay does not trust this server because it uses a certificate that is not valid for its hostname.", # TODO: Translate
     "startTLS-not-supported-client": "Este cliente no soporta TLS",
     "startTLS-not-supported-server": "Este servidor no soporta TLS",
 

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -321,6 +321,7 @@ it = {
     "startTLS-initiated": "Tentativo di connessione sicura in corso",
     "startTLS-secure-connection-ok": "Connessione sicura stabilita ({})",
     "startTLS-server-certificate-invalid": 'Connessione sicura non riuscita. Il certificato di sicurezza di questo server non è valido. La comunicazione potrebbe essere intercettata da una terza parte. Per ulteriori dettagli e informazioni sulla risoluzione del problema, clicca <a href="https://syncplay.pl/trouble">qui</a>.',
+    "startTLS-server-certificate-invalid-DNS-ID": "Syncplay does not trust this server because it uses a certificate that is not valid for its hostname.", # TODO: Translate
     "startTLS-not-supported-client": "Questo client non supporta TLS",
     "startTLS-not-supported-server": "Questo server non supporta TLS",
 

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -324,6 +324,7 @@ ru = {
     "startTLS-initiated": "Attempting secure connection",
     "startTLS-secure-connection-ok": "Secure connection established ({})",
     "startTLS-server-certificate-invalid": 'Secure connection failed. The server uses an invalid security certificate. This communication could be intercepted by a third party. For further details and troubleshooting see <a href="https://syncplay.pl/trouble">here</a>.',
+    "startTLS-server-certificate-invalid-DNS-ID": "Syncplay does not trust this server because it uses a certificate that is not valid for its hostname.",
     "startTLS-not-supported-client": "This client does not support TLS",
     "startTLS-not-supported-server": "This server does not support TLS",
 

--- a/syncplay/protocols.py
+++ b/syncplay/protocols.py
@@ -99,6 +99,8 @@ class SyncClientProtocol(JSONCommandProtocol):
                 self._client._clientSupportsTLS = False
             elif "certificate verify failed" in str(reason.value):
                 self.dropWithError(getMessage("startTLS-server-certificate-invalid"))
+            elif "mismatched_id=DNS_ID" in str(reason.value):
+                self.dropWithError(getMessage("startTLS-server-certificate-invalid-DNS-ID"))
         except:
             pass
         self._client.destroyProtocol()


### PR DESCRIPTION
When I was trying to make syncplay working with a self-signed certificate I had a reconnection loop.

The issue was related to the SAN (Subject Alternative Name) that was not correct in my certificate.
I think it can be usefull to detect this error.