### PR TITLE
Fix string equality checks

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -30,7 +30,7 @@ import syncplay
 from syncplay.messages import getMissingStrings
 
 missingStrings = getMissingStrings()
-if missingStrings is not None and missingStrings is not "":
+if missingStrings is not None and missingStrings != "":
     import warnings
     warnings.warn("MISSING/UNUSED STRINGS DETECTED:\n{}".format(missingStrings))
 

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -135,7 +135,7 @@ class SyncplayClient(object):
 
         if constants.DEBUG_MODE and constants.WARN_ABOUT_MISSING_STRINGS:
             missingStrings = getMissingStrings()
-            if missingStrings is not None and missingStrings is not "":
+            if missingStrings is not None and missingStrings != "":
                 self.ui.showDebugMessage("MISSING/UNUSED STRINGS DETECTED:\n{}".format(missingStrings))
 
     def initProtocol(self, protocol):

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -320,7 +320,7 @@ class ConfigDialog(QtWidgets.QDialog):
         try:
             self.lastCheckedForUpdates = settings.value("lastCheckedQt", None)
             if self.lastCheckedForUpdates:
-                if self.config["lastCheckedForUpdates"] is not None and self.config["lastCheckedForUpdates"] is not "":
+                if self.config["lastCheckedForUpdates"] is not None and self.config["lastCheckedForUpdates"] != "":
                     if self.lastCheckedForUpdates.toPython() > datetime.strptime(self.config["lastCheckedForUpdates"], "%Y-%m-%d %H:%M:%S.%f"):
                         self.config["lastCheckedForUpdates"] = self.lastCheckedForUpdates.toString("yyyy-MM-d HH:mm:ss.z")
                 else:


### PR DESCRIPTION
From the Python 3.8 [changelog](https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior):

> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. 