### PR TITLE
Fixes for OSX deploy issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ jobs:
     - language: objective-c
       os: osx
       osx_image: xcode9.2
-      addons:
-        homebrew:
-          packages:
-          - python
-          update: true
     - language: minimal
       dist: xenial
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
-matrix:
+# These two are defaults, which get overriden by the jobs matrix
+language: minimal
+os: linux
+
+jobs:
   include:
     - language: objective-c
+      os: osx
       osx_image: xcode8.3
     - language: bash
-      sudo: required
       dist: xenial
+      os: linux
       env: BUILD_DESTINATION=snapcraft
     - language: python
-      sudo: required
+      os: linux
       dist: xenial
       python: 3.6
       env: BUILD_DESTINATION=appimage
-
-branches:
-  only:
-  - master
 
 script:
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then python3 buildPy2app.py py2app ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
   include:
     - language: objective-c
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
     - language: minimal
       dist: xenial
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - language: objective-c
       os: osx
       osx_image: xcode8.3
-    - language: bash
+    - language: minimal
       dist: xenial
       os: linux
       env: BUILD_DESTINATION=snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
   include:
     - language: objective-c
       os: osx
-      osx_image: xcode9.2
+      osx_image: xcode8.3
     - language: minimal
       dist: xenial
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ jobs:
     - language: objective-c
       os: osx
       osx_image: xcode9.2
+      addons:
+        homebrew:
+          packages:
+          - python
+          update: true
     - language: minimal
       dist: xenial
       os: linux

--- a/travis/macos-deploy.sh
+++ b/travis/macos-deploy.sh
@@ -11,9 +11,3 @@ mkdir dist/Syncplay.app/Contents/Resources/es_419.lproj
 pip3 install dmgbuild
 mv syncplay/resources/macOS_readme.pdf syncplay/resources/.macOS_readme.pdf
 dmgbuild -s appdmg.py "Syncplay" dist_bintray/Syncplay_${VER}.dmg
-
-# Workaround for deployment issues with newer openssl.
-# See https://travis-ci.community/t/ruby-openssl-python-deployment-fails-on-osx-image/6753/9
-for lib in ssl crypto; do ln -s /usr/local/opt/openssl{@1.0,}/lib/lib${lib}.1.0.0.dylib; done
-rvm reinstall $(travis_internal_ruby) --disable-binary
-for lib in ssl crypto; do rm /usr/local/opt/openssl/lib/lib${lib}.1.0.0.dylib; done

--- a/travis/macos-deploy.sh
+++ b/travis/macos-deploy.sh
@@ -11,3 +11,9 @@ mkdir dist/Syncplay.app/Contents/Resources/es_419.lproj
 pip3 install dmgbuild
 mv syncplay/resources/macOS_readme.pdf syncplay/resources/.macOS_readme.pdf
 dmgbuild -s appdmg.py "Syncplay" dist_bintray/Syncplay_${VER}.dmg
+
+# Workaround for deployment issues with newer openssl.
+# See https://travis-ci.community/t/ruby-openssl-python-deployment-fails-on-osx-image/6753/9
+for lib in ssl crypto; do ln -s /usr/local/opt/openssl{@1.0,}/lib/lib${lib}.1.0.0.dylib; done
+rvm reinstall $(travis_internal_ruby) --disable-binary
+for lib in ssl crypto; do rm /usr/local/opt/openssl/lib/lib${lib}.1.0.0.dylib; done

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -12,11 +12,11 @@ python3 --version
 which pip3
 pip3 --version
 
-# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
-
 # Pyside 5.13.0 for 10.12 bottle
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/99219f0923014b24f33eae624fbfe83772c35f54/Formula/pyside.rb
+
+# Explicitly upgrade Qt 5.13.1 as the pyside above needs it
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
 
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-export HOMEBREW_NO_INSTALL_CLEANUP=1
-brew update
-brew upgrade python
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+brew install python
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -5,7 +5,7 @@ set -ex
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Reinstall openssl to fix Python pip install issues
-brew reinstall openssl@1.1
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/openssl@1.1.rb
 
 # Python 3.7.4 with 10.12 bottle
 brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -2,8 +2,9 @@
 
 set -ex
 
+export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew update
-brew install python3
+brew upgrade python
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-brew install python
+brew install python3
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -13,6 +13,10 @@ which pip3
 pip3 --version
 
 brew install albertosottile/syncplay/pyside
+
+# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
+
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 
 pip3 install py2app

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -12,10 +12,11 @@ python3 --version
 which pip3
 pip3 --version
 
-brew install albertosottile/syncplay/pyside
-
 # Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle
-brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
+
+# Pyside 5.13.0 for 10.12 bottle
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/99219f0923014b24f33eae624fbfe83772c35f54/Formula/pyside.rb
 
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 brew install python3
 which python3
 python3 --version

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -2,6 +2,15 @@
 
 set -ex
 
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+brew update
+
+# An error occurs when upgrading Python, but appears to be benign, hence the "|| true"
+#
+# Error: undefined method `any?' for nil:NilClass
+# /usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:227:in `depends_on'
+brew upgrade python || true
+
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -15,6 +15,10 @@ which python3
 python3 --version
 which pip3
 pip3 --version
+
+# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle 
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
+
 brew install albertosottile/syncplay/pyside
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -3,20 +3,16 @@
 set -ex
 
 export HOMEBREW_NO_INSTALL_CLEANUP=1
-brew update
 
-# An error occurs when upgrading Python, but appears to be benign, hence the "|| true"
-#
-# Error: undefined method `any?' for nil:NilClass
-# /usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:227:in `depends_on'
-brew upgrade python || true
+# Python 3.7.4 with 10.12 bottle
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
 
 which python3
 python3 --version
 which pip3
 pip3 --version
 
-# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle 
+# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
 
 brew install albertosottile/syncplay/pyside

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -5,7 +5,7 @@ set -ex
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Python 3.7.4 with 10.12 bottle
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
 
 which python3
 python3 --version

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -5,6 +5,7 @@ set -ex
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Python 3.7.4 with 10.12 bottle
+brew install openssl@1.1
 brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
 
 which python3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-brew update
-brew upgrade python
 which python3
 python3 --version
 which pip3

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+brew update
 brew install python3
 which python3
 python3 --version

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -5,8 +5,10 @@ set -ex
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Python 3.7.4 with 10.12 bottle
-brew install openssl@1.1
 brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
+
+# Reinstall openssl to fix Python pip install issues
+brew reinstall openssl@1.1
 
 which python3
 python3 --version
@@ -21,6 +23,7 @@ brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb
 
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 
+python3 -c "import ssl; print(ssl)"
 pip3 install py2app
 python3 -c "from py2app.recipes import pyside2"
 pip3 install twisted[tls] appnope requests certifi

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 brew install python3
 which python3
 python3 --version
 which pip3
 pip3 --version
-brew install albertosottile/syncplay/pyside
+brew install pyside
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 
 pip3 install py2app

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -4,11 +4,11 @@ set -ex
 
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
-# Python 3.7.4 with 10.12 bottle
-brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
-
 # Reinstall openssl to fix Python pip install issues
 brew reinstall openssl@1.1
+
+# Python 3.7.4 with 10.12 bottle
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e9004bd764c9436750a50e0b428548f68fe6a38a/Formula/python.rb
 
 which python3
 python3 --version

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -12,9 +12,6 @@ python3 --version
 which pip3
 pip3 --version
 
-# Explicitly install Qt 5.13.1 as that has both 10.12 compatibility, and a pre-built bottle
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/dcc34dd3cb24cb4f7cfa0047ccdb712d7cc4c6e4/Formula/qt.rb
-
 brew install albertosottile/syncplay/pyside
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 

--- a/travis/macos-install.sh
+++ b/travis/macos-install.sh
@@ -15,7 +15,7 @@ which python3
 python3 --version
 which pip3
 pip3 --version
-brew install pyside
+brew install albertosottile/syncplay/pyside
 python3 -c "from PySide2 import __version__; print(__version__)"
 python3 -c "from PySide2.QtCore import __version__; print(__version__)" 
 pip3 install py2app


### PR DESCRIPTION
Deploys appear to be failing due to an issue with Travis installing it's dpl gem. Others (https://travis-ci.community/t/ruby-openssl-python-deployment-fails-on-osx-image/6753) have had the same problem, and this is a workaround from there that should probably work but is hard to check until it's on master.