### PR TITLE
Fix macOS environment variable patchup:

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -40,8 +40,9 @@ from syncplay.constants import PRIVACY_SENDHASHED_MODE, PRIVACY_DONTSEND_MODE, \
     PRIVACY_HIDDENFILENAME
 from syncplay.messages import getMissingStrings, getMessage
 from syncplay.protocols import SyncClientProtocol
-from syncplay.utils import isMacOS
+from syncplay.utils import isMacOS, fixMacEnvironmentVars
 
+fixMacEnvironmentVars()
 
 class SyncClientFactory(ClientFactory):
     def __init__(self, client, retry=constants.RECONNECT_RETRIES):

--- a/syncplay/players/mplayer.py
+++ b/syncplay/players/mplayer.py
@@ -339,20 +339,7 @@ class MplayerPlayer(BasePlayer):
             env = os.environ.copy()
             if 'TERM' in env:
                 del env['TERM']
-            # On macOS, youtube-dl requires system python to run. Set the environment
-            # to allow that version of python to be executed in the mpv subprocess.
-            if isMacOS():
-                try:
-                    pythonLibs = subprocess.check_output(['/usr/bin/python', '-E', '-c',
-                                                          'import sys; print(sys.path)'],
-                                                          text=True, env=dict())
-                    pythonLibs = ast.literal_eval(pythonLibs)
-                    pythonPath = ':'.join(pythonLibs[1:])
-                except:
-                    pythonPath = None
-                if pythonPath is not None:
-                    env['PATH'] = '/usr/bin:/usr/local/bin'
-                    env['PYTHONPATH'] = pythonPath
+
             if filePath:
                 self.__process = subprocess.Popen(
                     call, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT,

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -506,3 +506,27 @@ class RandomStringGenerator(object):
 
 class NotControlledRoom(Exception):
     pass
+
+def fixMacEnvironmentVars():
+    if getattr(sys, 'frozen', None) != 'macosx_app':
+        return
+    # py2app, used on macOS, sets a number of environment variables
+    # which are meant for our own Python interpreter but will leak
+    # into youtube-dl invoked by mpv.
+    # The best we can do is unset them, though it would be better
+    # if we could restore the values they originally had before
+    # py2app changed them.
+    keys_to_remove = [key for key in os.environ if key.startswith('PYTHON')]
+    for key in keys_to_remove:
+        del os.environ[key]
+
+    # Also, add Homebrew to PATH even if it's not in the PATH used
+    # for apps.
+    paths = os.environ.get('PATH', '').split(':')
+    if paths == ['']:
+        paths = []
+    local = '/usr/local/bin'
+    if local not in paths:
+        paths.append(local)
+    os.environ['PATH'] = ':'.join(paths)
+


### PR DESCRIPTION
- Only apply when actually running under py2app, as opposed to whenever
  running on macOS.
- Instead of setting PATH to a fully hardcoded value, just append
  /usr/local/bin if not already present.  That way any non-default
  choices by the user are respected.
- Unset PYTHONPATH instead of setting it based on /usr/bin/python's
  sys.path.  mpv or other players could end up invoking any copy of
  Python, so there's no sensible value to set it to, but it's (normally)
  fine to leave it blank.  The important thing is that we don't keep the
  value set by py2app, pointing to our own Contents/Resources directory.
  (It should be safe to change PYTHONPATH at this point without
  affecting Syncplay's own execution, since Python only checks it at
  startup.)
- Unset other Python environment variables instead of just PYTHONPATH,
  because py2app sets a number of them (including
  PYTHONDONTWRITEBYTECODE and PYTHONHOME).
- Do the environment variable patchup when starting Syncplay, so it
  applies to all players rather than just mplayer-based ones.

Fixes #276.