### PR TITLE
Remove ruby reinstall workaround for openssl, as not needed

### DIFF
--- a/travis/macos-deploy.sh
+++ b/travis/macos-deploy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 mkdir dist/Syncplay.app/Contents/Resources/English.lproj
 mkdir dist/Syncplay.app/Contents/Resources/en_AU.lproj
 mkdir dist/Syncplay.app/Contents/Resources/en_GB.lproj
@@ -11,9 +13,3 @@ mkdir dist/Syncplay.app/Contents/Resources/es_419.lproj
 pip3 install dmgbuild
 mv syncplay/resources/macOS_readme.pdf syncplay/resources/.macOS_readme.pdf
 dmgbuild -s appdmg.py "Syncplay" dist_bintray/Syncplay_${VER}.dmg
-
-# Workaround for deployment issues with newer openssl.
-# See https://travis-ci.community/t/ruby-openssl-python-deployment-fails-on-osx-image/6753/9
-for lib in ssl crypto; do ln -s /usr/local/opt/openssl{@1.0,}/lib/lib${lib}.1.0.0.dylib; done
-rvm reinstall $(travis_internal_ruby) --disable-binary
-for lib in ssl crypto; do rm /usr/local/opt/openssl/lib/lib${lib}.1.0.0.dylib; done


### PR DESCRIPTION
So it turns out the workaround hack in #275 isn't needed any more, probably due to the homebrew changes there restricting the alterations to the filesystem. https://travis-ci.org/github/palfrey/syncplay/jobs/665559940 demos a upload being done, and other than it failing due to authorisation issues (which hopefully are just due to it being on my fork, not the main repo) it should hopefully work now!