### PR TITLE
 Use mpv's new create_osd_overlay API

### DIFF
--- a/syncplay/resources/syncplayintf.lua
+++ b/syncplay/resources/syncplayintf.lua
@@ -133,6 +133,7 @@ function add_chat(chat_message, mood)
 	chat_log[entry] = { xpos=CANVAS_WIDTH, timecreated=mp.get_time(), text=tostring(chat_message), row=row }
 end
 
+local old_ass_text = ''
 function chat_update()
     local ass = assdraw.ass_new()
 	local chat_ass = ''
@@ -179,7 +180,14 @@ function chat_update()
         ass:append(input_ass())
         ass:append(chat_ass)
     end
-	mp.set_osd_ass(CANVAS_WIDTH,CANVAS_HEIGHT, ass.text)
+
+    -- The commit that introduced the new API removed the internal heuristics on whether a refresh is required,
+    -- so we check for changed text manually to not cause excessive GPU load
+    -- https://github.com/mpv-player/mpv/commit/07287262513c0d1ea46b7beaf100e73f2008295f#diff-d88d582039dea993b6229da9f61ba76cL530
+    if ass.text ~= old_ass_text then
+		mp.set_osd_ass(CANVAS_WIDTH,CANVAS_HEIGHT, ass.text)
+		old_ass_text = ass.text
+	end
 end
 
 function process_alert_osd()

--- a/syncplay/resources/syncplayintf.lua
+++ b/syncplay/resources/syncplayintf.lua
@@ -204,7 +204,6 @@ function process_alert_osd()
         local messageString = wordwrapify_string(alert_osd)
         local startRow = 0
         if messageString ~= '' and messageString ~= nil then
-            local toDisplay
             rowsCreated = rowsCreated + 1
             messageString = messageColour..messageString
 			if stringToAdd ~= "" then
@@ -222,10 +221,8 @@ function process_notification_osd(startRow)
     local startRow = startRow
     local stringToAdd = ""
     if notification_osd ~= "" and mp.get_time() - last_notification_osd_time < opts['alertTimeout'] and last_notification_osd_time ~= nil then
-        local messageColour
-        messageColour = "{\\1c&H"..NOTIFICATION_TEXT_COLOUR.."}"
-        local messageString
-        messageString = wordwrapify_string(notification_osd)
+        local messageColour = "{\\1c&H"..NOTIFICATION_TEXT_COLOUR.."}"
+        local messageString = wordwrapify_string(notification_osd)
         messageString = messageColour..messageString
         messageString = format_chatroom(messageString)
         stringToAdd = messageString


### PR DESCRIPTION
The new API was added in https://github.com/mpv-player/mpv/commit/07287262513c0d1ea46b7beaf100e73f2008295f for mpv 0.31 and doesn't add new functionality, but it makes the existing private interface publicly available, so it should be used eventually. In my journey of fixing the performance regression, I also ported syncplay's code to use this new API.

This was rebased on top of #295 in order to merge cleanly.

I did not change any code regarding the minimum version requirement of mpv because I didn't know how you would like to do that. I see that there is still code supporting some old mpv client with a version lower than 0.6. Please decide for yourself how you want to handle this or whether you want to accept it at all. There is a legacy layer that will map to the new API without any functional differences (at least as of now).