### PR TITLE
Fixed crashes when trying to open YouTube videos with emojis

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -6,6 +6,7 @@ import os
 import os.path
 import random
 import re
+import string
 import sys
 import threading
 import time
@@ -1608,7 +1609,8 @@ class UiManager(object):
                     self.lastNotificationOSDEndTime = time.time() + constants.OSD_DURATION
                     if self.lastAlertOSDEndTime and time.time() < self.lastAlertOSDEndTime:
                         message = "{}{}{}".format(self.lastAlertOSDMessage, self._client._player.osdMessageSeparator, message)
-            self._client._player.displayMessage(message, int(duration * 1000), OSDType, mood)
+            printableMessage = ''.join(filter(lambda x: x in set(string.printable), message))
+            self._client._player.displayMessage(printableMessage, int(duration * 1000), OSDType, mood)
 
     def setControllerStatus(self, username, isController):
         self.__ui.setControllerStatus(username, isController)

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -6,7 +6,6 @@ import os
 import os.path
 import random
 import re
-import string
 import sys
 import threading
 import time
@@ -1609,8 +1608,7 @@ class UiManager(object):
                     self.lastNotificationOSDEndTime = time.time() + constants.OSD_DURATION
                     if self.lastAlertOSDEndTime and time.time() < self.lastAlertOSDEndTime:
                         message = "{}{}{}".format(self.lastAlertOSDMessage, self._client._player.osdMessageSeparator, message)
-            printableMessage = ''.join(filter(lambda x: x in set(string.printable), message))
-            self._client._player.displayMessage(printableMessage, int(duration * 1000), OSDType, mood)
+            self._client._player.displayMessage(message, int(duration * 1000), OSDType, mood)
 
     def setControllerStatus(self, username, isController):
         self.__ui.setControllerStatus(username, isController)

--- a/syncplay/players/mpc.py
+++ b/syncplay/players/mpc.py
@@ -1,7 +1,6 @@
 
 import os.path
 import re
-import string
 import time
 import threading
 import _thread
@@ -87,12 +86,12 @@ class MpcHcApi:
             _fields_ = [
                 ('nMsgPos', ctypes.c_int32),
                 ('nDurationMS', ctypes.c_int32),
-                ('strMsg', ctypes.c_wchar * (len(message) + 1))
+                ('strMsg', ctypes.c_wchar * (len(message.encode('utf-8')) + 1))
             ]
         cmessage = __OSDDATASTRUCT()
         cmessage.nMsgPos = MsgPos
         cmessage.nDurationMS = DurationMs
-        cmessage.strMsg = ''.join(filter(lambda x: x in string.printable, message))
+        cmessage.strMsg = message
         self.__listener.SendCommand(self.CMD_OSDSHOWMESSAGE, cmessage)
 
     def sendRawCommand(self, cmd, value):

--- a/syncplay/players/mpc.py
+++ b/syncplay/players/mpc.py
@@ -1,6 +1,7 @@
 
 import os.path
 import re
+import string
 import time
 import threading
 import _thread
@@ -91,7 +92,7 @@ class MpcHcApi:
         cmessage = __OSDDATASTRUCT()
         cmessage.nMsgPos = MsgPos
         cmessage.nDurationMS = DurationMs
-        cmessage.strMsg = message
+        cmessage.strMsg = ''.join(filter(lambda x: x in string.printable, message))
         self.__listener.SendCommand(self.CMD_OSDSHOWMESSAGE, cmessage)
 
     def sendRawCommand(self, cmd, value):

--- a/syncplay/players/mpc.py
+++ b/syncplay/players/mpc.py
@@ -1,7 +1,6 @@
 
 import os.path
 import re
-import string
 import time
 import threading
 import _thread
@@ -92,7 +91,7 @@ class MpcHcApi:
         cmessage = __OSDDATASTRUCT()
         cmessage.nMsgPos = MsgPos
         cmessage.nDurationMS = DurationMs
-        cmessage.strMsg = ''.join(filter(lambda x: x in string.printable, message))
+        cmessage.strMsg = message
         self.__listener.SendCommand(self.CMD_OSDSHOWMESSAGE, cmessage)
 
     def sendRawCommand(self, cmd, value):


### PR DESCRIPTION
Noticed that when I try to sync YouTube videos on MPC with `youtube-dl`.

If the video title contains emojis it starts disconnecting and reconnecting infinetely. 

Stacktrace:
```Unhandled Error
Traceback (most recent call last):
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\python\log.py", line 103, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\python\log.py", line 86, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\python\context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\python\context.py", line 85, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "D:\syncplayGit\syncplay\syncplay\vendor\qt5reactor.py", line 153, in _read
    why = w.doRead()
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\internet\tcp.py", line 243, in doRead
    return self._dataReceived(data)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\internet\tcp.py", line 249, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\internet\endpoints.py", line 132, in dataReceived
    return self._wrappedProtocol.dataReceived(data)
  File "C:\Users\VIKTOR\AppData\Local\Programs\Python\Python38\lib\site-packages\twisted\protocols\basic.py", line 572, in dataReceived
    why = self.lineReceived(line)
  File "D:\syncplayGit\syncplay\syncplay\protocols.py", line 55, in lineReceived
    self.handleMessages(messages)
  File "D:\syncplayGit\syncplay\syncplay\protocols.py", line 26, in handleMessages
    self.handleSet(message[1])
  File "D:\syncplayGit\syncplay\syncplay\protocols.py", line 175, in handleSet
    self._SetUser(values)
  File "D:\syncplayGit\syncplay\syncplay\protocols.py", line 167, in _SetUser
    self._client.userlist.modUser(username, room, file_)
  File "D:\syncplayGit\syncplay\syncplay\client.py", line 1372, in modUser
    self.__displayModUserMessage(username, room, file_, user, oldRoom)
  File "D:\syncplayGit\syncplay\syncplay\client.py", line 1362, in __displayModUserMessage
    self.__showUserChangeMessage(username, room, file_, oldRoom)
  File "D:\syncplayGit\syncplay\syncplay\client.py", line 1290, in __showUserChangeMessage
    self.ui.showMessage(message, hideFromOSD)
  File "D:\syncplayGit\syncplay\syncplay\client.py", line 1581, in showMessage
    self.showOSDMessage(message, duration=constants.OSD_DURATION, OSDType=OSDType, mood=mood)
  File "D:\syncplayGit\syncplay\syncplay\client.py", line 1611, in showOSDMessage
    self._client._player.displayMessage(message, int(duration * 1000), OSDType, mood)
  File "D:\syncplayGit\syncplay\syncplay\players\mpc.py", line 416, in displayMessage
    self._mpcApi.sendOsd(message, constants.MPC_OSD_POSITION, duration)
  File "D:\syncplayGit\syncplay\syncplay\players\mpc.py", line 94, in sendOsd
    cmessage.strMsg = message
builtins.ValueError: string too long (111, maximum length 109)
```

Added filter for non-ASCII characters to solve the issue.