### PR TITLE
Change Alignement Operator -- Make conversion QPixmap --> QIcon explicit -- Use lambda to connect() to functions behind a wrapper

### DIFF
--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -1181,7 +1181,7 @@ class ConfigDialog(QtWidgets.QDialog):
 
         self.displaySettingsGroup = QtWidgets.QGroupBox(getMessage("messages-other-title"))
         self.displaySettingsLayout = QtWidgets.QVBoxLayout()
-        self.displaySettingsLayout.setAlignment(Qt.AlignTop & Qt.AlignLeft)
+        self.displaySettingsLayout.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         self.displaySettingsFrame = QtWidgets.QFrame()
 
         self.showDurationNotificationCheckbox = QCheckBox(getMessage("showdurationnotification-label"))
@@ -1193,7 +1193,7 @@ class ConfigDialog(QtWidgets.QDialog):
         self.languageLayout.setContentsMargins(0, 0, 0, 0)
         self.languageFrame.setLayout(self.languageLayout)
         self.languageFrame.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Minimum)
-        self.languageLayout.setAlignment(Qt.AlignTop & Qt.AlignLeft)
+        self.languageLayout.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         self.languageLabel = QLabel(getMessage("language-label"), self)
         self.languageCombobox = QtWidgets.QComboBox(self)
         self.languageCombobox.addItem(getMessage("automatic-language").format(getMessage("LANGUAGE", getInitialLanguage())))
@@ -1214,7 +1214,7 @@ class ConfigDialog(QtWidgets.QDialog):
 
         self.displaySettingsGroup.setLayout(self.displaySettingsLayout)
         self.displaySettingsGroup.setMaximumHeight(self.displaySettingsGroup.minimumSizeHint().height())
-        self.displaySettingsLayout.setAlignment(Qt.AlignTop & Qt.AlignLeft)
+        self.displaySettingsLayout.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         self.messageLayout.addWidget(self.displaySettingsGroup)
 
         # messageFrame

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -1394,7 +1394,7 @@ class ConfigDialog(QtWidgets.QDialog):
         self.publicServerAddresses = []
 
         self._playerProbeThread = GetPlayerIconThread()
-        self._playerProbeThread.done.connect(self._updateExecutableIcon)
+        self._playerProbeThread.done.connect(lambda iconpath, playerpath: self._updateExecutableIcon(iconpath, playerpath))
         self._playerProbeThread.start()
 
         if self.config['clearGUIData'] == True:

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -1457,7 +1457,7 @@ class MainWindow(QtWidgets.QMainWindow):
             window.sslButton.setVisible(False)
             window.sslButton.setFixedHeight(27)
             window.sslButton.setFixedWidth(27)
-        window.sslButton.pressed.connect(self.openSSLDetails)
+        window.sslButton.pressed.connect(lambda: self.openSSLDetails())
         window.sslButton.setToolTip(getMessage("sslconnection-tooltip"))
         window.listFrame = QtWidgets.QFrame()
         window.listFrame.setLineWidth(0)
@@ -1487,7 +1487,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.roomButton = QtWidgets.QPushButton(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'door_in.png')),
             getMessage("joinroom-label"))
-        window.roomButton.pressed.connect(self.joinRoom)
+        window.roomButton.pressed.connect(lambda room=None: self.joinRoom(room))
         window.roomButton.setFixedWidth(window.roomButton.sizeHint().width()+3)
         window.roomLayout = QtWidgets.QHBoxLayout()
         window.roomFrame = QtWidgets.QFrame()
@@ -1539,10 +1539,10 @@ class MainWindow(QtWidgets.QMainWindow):
         window.playlist.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         window.playlist.setDefaultDropAction(Qt.MoveAction)
         window.playlist.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
-        window.playlist.doubleClicked.connect(self.playlistItemClicked)
+        window.playlist.doubleClicked.connect(lambda item: self.playlistItemClicked(item))
         window.playlist.setContextMenuPolicy(Qt.CustomContextMenu)
         window.playlist.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
-        window.playlist.customContextMenuRequested.connect(self.openPlaylistMenu)
+        window.playlist.customContextMenuRequested.connect(lambda position: self.openPlaylistMenu(position))
         self.playlistUpdateTimer = task.LoopingCall(self.playlistChangeCheck)
         self.playlistUpdateTimer.start(0.1, True)
         noteFont = QtGui.QFont()
@@ -1579,7 +1579,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.autoplayPushButton.setText(getMessage("autoplay-guipushbuttonlabel"))
         window.autoplayPushButton.setCheckable(True)
         window.autoplayPushButton.setAutoExclusive(False)
-        window.autoplayPushButton.toggled.connect(self.changeAutoplayState)
+        window.autoplayPushButton.toggled.connect(lambda source=None: self.changeAutoplayState(source))
         window.autoplayPushButton.setFont(autoPlayFont)
         if isMacOS():
             window.autoplayFrame.setMinimumWidth(window.listFrame.sizeHint().width())
@@ -1600,7 +1600,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.autoplayThresholdSpinbox.setMinimum(2)
         window.autoplayThresholdSpinbox.setMaximum(99)
         window.autoplayThresholdSpinbox.setToolTip(getMessage("autoplay-tooltip"))
-        window.autoplayThresholdSpinbox.valueChanged.connect(self.changeAutoplayThreshold)
+        window.autoplayThresholdSpinbox.valueChanged.connect(lambda source=None: self.changeAutoplayThreshold(source))
         window.autoplayLayout.addWidget(window.autoplayPushButton, Qt.AlignRight)
         window.autoplayLayout.addWidget(window.autoplayLabel, Qt.AlignRight)
         window.autoplayLayout.addWidget(window.autoplayThresholdSpinbox, Qt.AlignRight)
@@ -1629,17 +1629,17 @@ class MainWindow(QtWidgets.QMainWindow):
         window.playbackLayout.addWidget(window.seekButton)
         window.unseekButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'arrow_undo.png')), "")
         window.unseekButton.setToolTip(getMessage("undoseek-menu-label"))
-        window.unseekButton.pressed.connect(self.undoSeek)
+        window.unseekButton.pressed.connect(lambda: self.undoSeek())
 
         window.miscLayout = QtWidgets.QHBoxLayout()
         window.playbackLayout.addWidget(window.unseekButton)
         window.playButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_play_blue.png')), "")
         window.playButton.setToolTip(getMessage("play-menu-label"))
-        window.playButton.pressed.connect(self.play)
+        window.playButton.pressed.connect(lambda: self.play())
         window.playbackLayout.addWidget(window.playButton)
         window.pauseButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_pause_blue.png')), "")
         window.pauseButton.setToolTip(getMessage("pause-menu-label"))
-        window.pauseButton.pressed.connect(self.pause)
+        window.pauseButton.pressed.connect(lambda: self.pause())
         window.playbackLayout.addWidget(window.pauseButton)
         window.playbackFrame.setMaximumHeight(window.playbackFrame.sizeHint().height())
         window.playbackFrame.setMaximumWidth(window.playbackFrame.sizeHint().width())
@@ -1659,20 +1659,20 @@ class MainWindow(QtWidgets.QMainWindow):
         window.fileMenu = QtWidgets.QMenu(getMessage("file-menu-label"), self)
         window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'folder_explore.png')),
                                                       getMessage("openmedia-menu-label"))
-        window.openAction.triggered.connect(self.browseMediapath)
+        window.openAction.triggered.connect(lambda: self.browseMediapath())
         window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'world_explore.png')),
                                                       getMessage("openstreamurl-menu-label"))
-        window.openAction.triggered.connect(self.promptForStreamURL)
+        window.openAction.triggered.connect(lambda: self.promptForStreamURL())
         window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'film_folder_edit.png')),
                                                       getMessage("setmediadirectories-menu-label"))
-        window.openAction.triggered.connect(self.openSetMediaDirectoriesDialog)
+        window.openAction.triggered.connect(lambda: self.openSetMediaDirectoriesDialog())
 
         window.exitAction = window.fileMenu.addAction(getMessage("exit-menu-label"))
         if isMacOS():
             window.exitAction.setMenuRole(QtWidgets.QAction.QuitRole)
         else:
             window.exitAction.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'cross.png')))
-        window.exitAction.triggered.connect(self.exitSyncplay)
+        window.exitAction.triggered.connect(lambda: self.exitSyncplay())
 
         if(window.editMenu is not None):
             window.menuBar.insertMenu(window.editMenu.menuAction(), window.fileMenu)
@@ -1685,11 +1685,11 @@ class MainWindow(QtWidgets.QMainWindow):
         window.playAction = window.playbackMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_play_blue.png')),
             getMessage("play-menu-label"))
-        window.playAction.triggered.connect(self.play)
+        window.playAction.triggered.connect(lambda: self.play())
         window.pauseAction = window.playbackMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_pause_blue.png')),
             getMessage("pause-menu-label"))
-        window.pauseAction.triggered.connect(self.pause)
+        window.pauseAction.triggered.connect(lambda: self.pause())
         window.seekAction = window.playbackMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'clock_go.png')),
             getMessage("seektime-menu-label"))
@@ -1697,7 +1697,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.unseekAction = window.playbackMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'arrow_undo.png')),
             getMessage("undoseek-menu-label"))
-        window.unseekAction.triggered.connect(self.undoSeek)
+        window.unseekAction.triggered.connect(lambda: self.undoSeek())
 
         window.menuBar.addMenu(window.playbackMenu)
 
@@ -1707,17 +1707,17 @@ class MainWindow(QtWidgets.QMainWindow):
         window.setoffsetAction = window.advancedMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'timeline_marker.png')),
             getMessage("setoffset-menu-label"))
-        window.setoffsetAction.triggered.connect(self.setOffset)
+        window.setoffsetAction.triggered.connect(lambda: self.setOffset())
         window.setTrustedDomainsAction = window.advancedMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'shield_edit.png')),
             getMessage("settrusteddomains-menu-label"))
-        window.setTrustedDomainsAction.triggered.connect(self.openSetTrustedDomainsDialog)
+        window.setTrustedDomainsAction.triggered.connect(lambda: self.openSetTrustedDomainsDialog())
         window.createcontrolledroomAction = window.advancedMenu.addAction(
             QtGui.QIcon(QtGui.QPixmap(resourcespath + 'page_white_key.png')), getMessage("createcontrolledroom-menu-label"))
-        window.createcontrolledroomAction.triggered.connect(self.createControlledRoom)
+        window.createcontrolledroomAction.triggered.connect(lambda: self.createControlledRoom())
         window.identifyascontroller = window.advancedMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'key_go.png')),
                                                                     getMessage("identifyascontroller-menu-label"))
-        window.identifyascontroller.triggered.connect(self.identifyAsController)
+        window.identifyascontroller.triggered.connect(lambda: self.identifyAsController())
 
         window.menuBar.addMenu(window.advancedMenu)
 

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -139,7 +139,7 @@ class AboutDialog(QtWidgets.QDialog):
             self.setWindowTitle(getMessage("about-dialog-title"))
             if isWindows():
                 self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
-        self.setWindowIcon(QtGui.QPixmap(resourcespath + 'syncplay.png'))
+        self.setWindowIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'syncplay.png')))
         nameLabel = QtWidgets.QLabel("<center><strong>Syncplay</strong></center>")
         nameLabel.setFont(QtGui.QFont("Helvetica", 18))
         linkLabel = QtWidgets.QLabel()
@@ -202,7 +202,7 @@ class CertificateDialog(QtWidgets.QDialog):
             self.setWindowTitle(getMessage("tls-information-title"))
             if isWindows():
                 self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
-        self.setWindowIcon(QtGui.QPixmap(resourcespath + 'syncplay.png'))
+        self.setWindowIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'syncplay.png')))
         statusLabel = QtWidgets.QLabel(getMessage("tls-dialog-status-label").format(tlsData["subject"]))
         descLabel = QtWidgets.QLabel(getMessage("tls-dialog-desc-label").format(tlsData["subject"]))
         connDataLabel = QtWidgets.QLabel(getMessage("tls-dialog-connection-label").format(tlsData["protocolVersion"], tlsData["cipher"]))
@@ -614,11 +614,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
             if isControlledRoom:
                 if room == currentUser.room and currentUser.isController():
-                    roomitem.setIcon(QtGui.QPixmap(resourcespath + 'lock_open.png'))
+                    roomitem.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'lock_open.png')))
                 else:
-                    roomitem.setIcon(QtGui.QPixmap(resourcespath + 'lock.png'))
+                    roomitem.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'lock.png')))
             else:
-                roomitem.setIcon(QtGui.QPixmap(resourcespath + 'chevrons_right.png'))
+                roomitem.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'chevrons_right.png')))
 
             for user in rooms[room]:
                 useritem = QtGui.QStandardItem(user.username)
@@ -719,31 +719,31 @@ class MainWindow(QtWidgets.QMainWindow):
             pathFound = self._syncplayClient.fileSwitch.findFilepath(firstFile) if not isURL(firstFile) else None
             if self._syncplayClient.userlist.currentUser.file is None or firstFile != self._syncplayClient.userlist.currentUser.file["name"]:
                 if isURL(firstFile):
-                    menu.addAction(QtGui.QPixmap(resourcespath + "world_go.png"), getMessage("openstreamurl-menu-label"), lambda: self.openFile(firstFile, resetPosition=True, fromUser=True))
+                    menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "world_go.png")), getMessage("openstreamurl-menu-label"), lambda: self.openFile(firstFile, resetPosition=True, fromUser=True))
                 elif pathFound:
-                        menu.addAction(QtGui.QPixmap(resourcespath + "film_go.png"), getMessage("openmedia-menu-label"), lambda: self.openFile(pathFound, resetPosition=True, fromUser=True))
+                        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_go.png")), getMessage("openmedia-menu-label"), lambda: self.openFile(pathFound, resetPosition=True, fromUser=True))
             if pathFound:
-                menu.addAction(QtGui.QPixmap(resourcespath + "folder_film.png"),
+                menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "folder_film.png")),
                                getMessage('open-containing-folder'),
                                lambda: utils.open_system_file_browser(pathFound))
             if self._syncplayClient.isUntrustedTrustableURI(firstFile):
                 domain = utils.getDomainFromURL(firstFile)
-                menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
-            menu.addAction(QtGui.QPixmap(resourcespath + "delete.png"), getMessage("removefromplaylist-menu-label"), lambda: self.deleteSelectedPlaylistItems())
+                menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "shield_add.png")), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
+            menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "delete.png")), getMessage("removefromplaylist-menu-label"), lambda: self.deleteSelectedPlaylistItems())
             menu.addSeparator()
-        menu.addAction(QtGui.QPixmap(resourcespath + "arrow_switch.png"), getMessage("shuffleremainingplaylist-menu-label"), lambda: self.shuffleRemainingPlaylist())
-        menu.addAction(QtGui.QPixmap(resourcespath + "arrow_switch.png"), getMessage("shuffleentireplaylist-menu-label"), lambda: self.shuffleEntirePlaylist())
-        menu.addAction(QtGui.QPixmap(resourcespath + "arrow_undo.png"), getMessage("undoplaylist-menu-label"), lambda: self.undoPlaylistChange())
-        menu.addAction(QtGui.QPixmap(resourcespath + "film_edit.png"), getMessage("editplaylist-menu-label"), lambda: self.openEditPlaylistDialog())
-        menu.addAction(QtGui.QPixmap(resourcespath + "film_add.png"), getMessage("addfilestoplaylist-menu-label"), lambda: self.OpenAddFilesToPlaylistDialog())
-        menu.addAction(QtGui.QPixmap(resourcespath + "world_add.png"), getMessage("addurlstoplaylist-menu-label"), lambda: self.OpenAddURIsToPlaylistDialog())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "arrow_switch.png")), getMessage("shuffleremainingplaylist-menu-label"), lambda: self.shuffleRemainingPlaylist())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "arrow_switch.png")), getMessage("shuffleentireplaylist-menu-label"), lambda: self.shuffleEntirePlaylist())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "arrow_undo.png")), getMessage("undoplaylist-menu-label"), lambda: self.undoPlaylistChange())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_edit.png")), getMessage("editplaylist-menu-label"), lambda: self.openEditPlaylistDialog())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_add.png")), getMessage("addfilestoplaylist-menu-label"), lambda: self.OpenAddFilesToPlaylistDialog())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "world_add.png")), getMessage("addurlstoplaylist-menu-label"), lambda: self.OpenAddURIsToPlaylistDialog())
         menu.addSeparator()
         menu.addAction(getMessage("loadplaylistfromfile-menu-label"),lambda: self.OpenLoadPlaylistFromFileDialog()) # TODO: Add icon
         menu.addAction("Load and shuffle playlist from file",lambda: self.OpenLoadPlaylistFromFileDialog(shuffle=True))  # TODO: Add icon and messages_en
         menu.addAction(getMessage("saveplaylisttofile-menu-label"),lambda: self.OpenSavePlaylistToFileDialog()) # TODO: Add icon
         menu.addSeparator()
-        menu.addAction(QtGui.QPixmap(resourcespath + "film_folder_edit.png"), getMessage("setmediadirectories-menu-label"), lambda: self.openSetMediaDirectoriesDialog())
-        menu.addAction(QtGui.QPixmap(resourcespath + "shield_edit.png"), getMessage("settrusteddomains-menu-label"), lambda: self.openSetTrustedDomainsDialog())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_folder_edit.png")), getMessage("setmediadirectories-menu-label"), lambda: self.openSetMediaDirectoriesDialog())
+        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "shield_edit.png")), getMessage("settrusteddomains-menu-label"), lambda: self.openSetTrustedDomainsDialog())
         menu.exec_(self.playlist.viewport().mapToGlobal(position))
 
     def openRoomMenu(self, position):
@@ -778,25 +778,25 @@ class MainWindow(QtWidgets.QMainWindow):
         elif username and filename and filename != getMessage("nofile-note"):
             if self.config['sharedPlaylistEnabled'] and not self.isItemInPlaylist(filename):
                 if isURL(filename):
-                    menu.addAction(QtGui.QPixmap(resourcespath + "world_add.png"), addUsersStreamToPlaylistLabelText, lambda: self.addStreamToPlaylist(filename))
+                    menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "world_add.png")), addUsersStreamToPlaylistLabelText, lambda: self.addStreamToPlaylist(filename))
                 else:
-                    menu.addAction(QtGui.QPixmap(resourcespath + "film_add.png"), addUsersFileToPlaylistLabelText, lambda: self.addStreamToPlaylist(filename))
+                    menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_add.png")), addUsersFileToPlaylistLabelText, lambda: self.addStreamToPlaylist(filename))
 
             if self._syncplayClient.userlist.currentUser.file is None or filename != self._syncplayClient.userlist.currentUser.file["name"]:
                 if isURL(filename):
-                    menu.addAction(QtGui.QPixmap(resourcespath + "world_go.png"), getMessage("openusersstream-menu-label").format(shortUsername), lambda: self.openFile(filename, resetPosition=False, fromUser=True))
+                    menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "world_go.png")), getMessage("openusersstream-menu-label").format(shortUsername), lambda: self.openFile(filename, resetPosition=False, fromUser=True))
                 else:
                     pathFound = self._syncplayClient.fileSwitch.findFilepath(filename)
                     if pathFound:
-                        menu.addAction(QtGui.QPixmap(resourcespath + "film_go.png"), getMessage("openusersfile-menu-label").format(shortUsername), lambda: self.openFile(pathFound, resetPosition=False, fromUser=True))
+                        menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "film_go.png")), getMessage("openusersfile-menu-label").format(shortUsername), lambda: self.openFile(pathFound, resetPosition=False, fromUser=True))
             if self._syncplayClient.isUntrustedTrustableURI(filename):
                 domain = utils.getDomainFromURL(filename)
-                menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
+                menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "shield_add.png")), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
 
             if not isURL(filename) and filename != getMessage("nofile-note"):
                 path = self._syncplayClient.fileSwitch.findFilepath(filename)
                 if path:
-                    menu.addAction(QtGui.QPixmap(resourcespath + "folder_film.png"), getMessage('open-containing-folder'), lambda: utils.open_system_file_browser(path))
+                    menu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + "folder_film.png")), getMessage('open-containing-folder'), lambda: utils.open_system_file_browser(path))
         else:
             return
         menu.exec_(self.listTreeView.viewport().mapToGlobal(position))
@@ -1410,7 +1410,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.chatInput.setMaxLength(constants.MAX_CHAT_MESSAGE_LENGTH)
         window.chatInput.returnPressed.connect(self.sendChatMessage)
         window.chatButton = QtWidgets.QPushButton(
-            QtGui.QPixmap(resourcespath + 'email_go.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'email_go.png')),
             getMessage("sendmessage-label"))
         window.chatButton.pressed.connect(self.sendChatMessage)
         window.chatLayout = QtWidgets.QHBoxLayout()
@@ -1445,7 +1445,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.listlabel = QtWidgets.QLabel(getMessage("userlist-heading-label"))
         if isMacOS:
             window.listlabel.setMinimumHeight(21)
-            window.sslButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'lock_green.png').scaled(14, 14),"")
+            window.sslButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'lock_green.png').scaled(14, 14)),"")
             window.sslButton.setVisible(False)
             window.sslButton.setFixedHeight(21)
             window.sslButton.setFixedWidth(21)
@@ -1453,7 +1453,7 @@ class MainWindow(QtWidgets.QMainWindow):
             window.sslButton.setStyleSheet("QPushButton:!hover{border: 1px solid gray;} QPushButton:hover{border:2px solid black;}")
         else:
             window.listlabel.setMinimumHeight(27)
-            window.sslButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'lock_green.png'),"")
+            window.sslButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'lock_green.png')),"")
             window.sslButton.setVisible(False)
             window.sslButton.setFixedHeight(27)
             window.sslButton.setFixedWidth(27)
@@ -1485,7 +1485,7 @@ class MainWindow(QtWidgets.QMainWindow):
         window.roomsCombobox.setEditable(True)
         #window.roomsCombobox.setMaxLength(constants.MAX_ROOM_NAME_LENGTH)
         window.roomButton = QtWidgets.QPushButton(
-            QtGui.QPixmap(resourcespath + 'door_in.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'door_in.png')),
             getMessage("joinroom-label"))
         window.roomButton.pressed.connect(self.joinRoom)
         window.roomButton.setFixedWidth(window.roomButton.sizeHint().width()+3)
@@ -1620,24 +1620,24 @@ class MainWindow(QtWidgets.QMainWindow):
         window.playbackFrame.setLayout(window.playbackLayout)
         window.seekInput = QtWidgets.QLineEdit()
         window.seekInput.returnPressed.connect(self.seekFromButton)
-        window.seekButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'clock_go.png'), "")
+        window.seekButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'clock_go.png')), "")
         window.seekButton.setToolTip(getMessage("seektime-menu-label"))
         window.seekButton.pressed.connect(self.seekFromButton)
         window.seekInput.setText("0:00")
         window.seekInput.setFixedWidth(60)
         window.playbackLayout.addWidget(window.seekInput)
         window.playbackLayout.addWidget(window.seekButton)
-        window.unseekButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'arrow_undo.png'), "")
+        window.unseekButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'arrow_undo.png')), "")
         window.unseekButton.setToolTip(getMessage("undoseek-menu-label"))
         window.unseekButton.pressed.connect(self.undoSeek)
 
         window.miscLayout = QtWidgets.QHBoxLayout()
         window.playbackLayout.addWidget(window.unseekButton)
-        window.playButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'control_play_blue.png'), "")
+        window.playButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_play_blue.png')), "")
         window.playButton.setToolTip(getMessage("play-menu-label"))
         window.playButton.pressed.connect(self.play)
         window.playbackLayout.addWidget(window.playButton)
-        window.pauseButton = QtWidgets.QPushButton(QtGui.QPixmap(resourcespath + 'control_pause_blue.png'), "")
+        window.pauseButton = QtWidgets.QPushButton(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_pause_blue.png')), "")
         window.pauseButton.setToolTip(getMessage("pause-menu-label"))
         window.pauseButton.pressed.connect(self.pause)
         window.playbackLayout.addWidget(window.pauseButton)
@@ -1657,13 +1657,13 @@ class MainWindow(QtWidgets.QMainWindow):
         # File menu
 
         window.fileMenu = QtWidgets.QMenu(getMessage("file-menu-label"), self)
-        window.openAction = window.fileMenu.addAction(QtGui.QPixmap(resourcespath + 'folder_explore.png'),
+        window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'folder_explore.png')),
                                                       getMessage("openmedia-menu-label"))
         window.openAction.triggered.connect(self.browseMediapath)
-        window.openAction = window.fileMenu.addAction(QtGui.QPixmap(resourcespath + 'world_explore.png'),
+        window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'world_explore.png')),
                                                       getMessage("openstreamurl-menu-label"))
         window.openAction.triggered.connect(self.promptForStreamURL)
-        window.openAction = window.fileMenu.addAction(QtGui.QPixmap(resourcespath + 'film_folder_edit.png'),
+        window.openAction = window.fileMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'film_folder_edit.png')),
                                                       getMessage("setmediadirectories-menu-label"))
         window.openAction.triggered.connect(self.openSetMediaDirectoriesDialog)
 
@@ -1671,7 +1671,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if isMacOS():
             window.exitAction.setMenuRole(QtWidgets.QAction.QuitRole)
         else:
-            window.exitAction.setIcon(QtGui.QPixmap(resourcespath + 'cross.png'))
+            window.exitAction.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'cross.png')))
         window.exitAction.triggered.connect(self.exitSyncplay)
 
         if(window.editMenu is not None):
@@ -1683,19 +1683,19 @@ class MainWindow(QtWidgets.QMainWindow):
 
         window.playbackMenu = QtWidgets.QMenu(getMessage("playback-menu-label"), self)
         window.playAction = window.playbackMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'control_play_blue.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_play_blue.png')),
             getMessage("play-menu-label"))
         window.playAction.triggered.connect(self.play)
         window.pauseAction = window.playbackMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'control_pause_blue.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'control_pause_blue.png')),
             getMessage("pause-menu-label"))
         window.pauseAction.triggered.connect(self.pause)
         window.seekAction = window.playbackMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'clock_go.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'clock_go.png')),
             getMessage("seektime-menu-label"))
         window.seekAction.triggered.connect(self.seekPositionDialog)
         window.unseekAction = window.playbackMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'arrow_undo.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'arrow_undo.png')),
             getMessage("undoseek-menu-label"))
         window.unseekAction.triggered.connect(self.undoSeek)
 
@@ -1705,17 +1705,17 @@ class MainWindow(QtWidgets.QMainWindow):
 
         window.advancedMenu = QtWidgets.QMenu(getMessage("advanced-menu-label"), self)
         window.setoffsetAction = window.advancedMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'timeline_marker.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'timeline_marker.png')),
             getMessage("setoffset-menu-label"))
         window.setoffsetAction.triggered.connect(self.setOffset)
         window.setTrustedDomainsAction = window.advancedMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'shield_edit.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'shield_edit.png')),
             getMessage("settrusteddomains-menu-label"))
         window.setTrustedDomainsAction.triggered.connect(self.openSetTrustedDomainsDialog)
         window.createcontrolledroomAction = window.advancedMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'page_white_key.png'), getMessage("createcontrolledroom-menu-label"))
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'page_white_key.png')), getMessage("createcontrolledroom-menu-label"))
         window.createcontrolledroomAction.triggered.connect(self.createControlledRoom)
-        window.identifyascontroller = window.advancedMenu.addAction(QtGui.QPixmap(resourcespath + 'key_go.png'),
+        window.identifyascontroller = window.advancedMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'key_go.png')),
                                                                     getMessage("identifyascontroller-menu-label"))
         window.identifyascontroller.triggered.connect(self.identifyAsController)
 
@@ -1725,7 +1725,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         window.windowMenu = QtWidgets.QMenu(getMessage("window-menu-label"), self)
 
-        window.editroomsAction = window.windowMenu.addAction(QtGui.QPixmap(resourcespath + 'door_open_edit.png'), getMessage("roomlist-msgbox-label"))
+        window.editroomsAction = window.windowMenu.addAction(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'door_open_edit.png')), getMessage("roomlist-msgbox-label"))
         window.editroomsAction.triggered.connect(self.openEditRoomsDialog)
         window.menuBar.addMenu(window.windowMenu)
 
@@ -1743,18 +1743,18 @@ class MainWindow(QtWidgets.QMainWindow):
         window.helpMenu = QtWidgets.QMenu(getMessage("help-menu-label"), self)
 
         window.userguideAction = window.helpMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'help.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'help.png')),
             getMessage("userguide-menu-label"))
         window.userguideAction.triggered.connect(self.openUserGuide)
         window.updateAction = window.helpMenu.addAction(
-            QtGui.QPixmap(resourcespath + 'application_get.png'),
+            QtGui.QIcon(QtGui.QPixmap(resourcespath + 'application_get.png')),
             getMessage("update-menu-label"))
         window.updateAction.triggered.connect(self.userCheckForUpdates)
 
         if not isMacOS():
             window.helpMenu.addSeparator()
             window.about = window.helpMenu.addAction(
-                QtGui.QPixmap(resourcespath + 'syncplay.png'),
+                QtGui.QIcon(QtGui.QPixmap(resourcespath + 'syncplay.png')),
                 getMessage("about-menu-label"))
         else:
             window.about = window.helpMenu.addAction("&About")
@@ -1835,16 +1835,16 @@ class MainWindow(QtWidgets.QMainWindow):
     def updateReadyIcon(self):
         ready = self.readyPushButton.isChecked()
         if ready:
-            self.readyPushButton.setIcon(QtGui.QPixmap(resourcespath + 'tick_checkbox.png'))
+            self.readyPushButton.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'tick_checkbox.png')))
         else:
-            self.readyPushButton.setIcon(QtGui.QPixmap(resourcespath + 'empty_checkbox.png'))
+            self.readyPushButton.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'empty_checkbox.png')))
 
     def updateAutoPlayIcon(self):
         ready = self.autoplayPushButton.isChecked()
         if ready:
-            self.autoplayPushButton.setIcon(QtGui.QPixmap(resourcespath + 'tick_checkbox.png'))
+            self.autoplayPushButton.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'tick_checkbox.png')))
         else:
-            self.autoplayPushButton.setIcon(QtGui.QPixmap(resourcespath + 'empty_checkbox.png'))
+            self.autoplayPushButton.setIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + 'empty_checkbox.png')))
 
     def automaticUpdateCheck(self):
         currentDateTimeValue = QDateTime.currentDateTime()
@@ -2060,7 +2060,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.populateMenubar(self)
         self.addMainFrame(self)
         self.loadSettings()
-        self.setWindowIcon(QtGui.QPixmap(resourcespath + "syncplay.png"))
+        self.setWindowIcon(QtGui.QIcon(QtGui.QPixmap(resourcespath + "syncplay.png")))
         self.setWindowFlags(self.windowFlags() & Qt.WindowCloseButtonHint & Qt.WindowMinimizeButtonHint & ~Qt.WindowContextHelpButtonHint)
         self.show()
         self.setAcceptDrops(True)


### PR DESCRIPTION
Hi,

I had to make the following changes to get this to run with PyQt5.

Mostly the changes are trivial:
- Import `IsPyQt5` and use it in if statements
- Make conversion of QPixmap to QIcon explicit where needed, for some reason PyQt5 doesn't do this automatically while PySide2 does.
- Use `|` operator instead of `&` in alignment, as I understand it this is not exactly the same, but PyQt5 complains about the `&` operator, and the result is visually identical as far as I can tell. So I think it should be fine to change this.

And then there were two issues I ran into that I sort of managed to create an ugly workaround for. There probably is a better solution than my ugly workaround, but I'll need your help and expertise to find it because I could not. You can find my workarounds on line 1397 in GuiConfiguration.py and line 456 in gui.py, along with a `To-Do:` comment.

Please let me know what you think about this, it would be great to have both PyQt5 and PySide2 compatibility in my opinion.