### PR TITLE
Re-enable youtube-dl on macOS plus mpv and IINA

### DIFF
--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -590,7 +590,7 @@ class MpvPlayer(BasePlayer):
             # to allow that version of python to be executed in the mpv subprocess.
             if isMacOS():
                 try:
-                    env['PATH'] = '/usr/local/bin:/usr/bin'
+                    env['PATH'] = '/opt/homebrew/bin:/usr/local/bin:/usr/bin'
                     ytdl_path = subprocess.check_output(['which', 'youtube-dl'], text=True, env=env).rstrip('\n')
                     with open(ytdl_path, 'rb') as f:
                         ytdl_shebang = f.readline()

--- a/syncplay/players/mpv.py
+++ b/syncplay/players/mpv.py
@@ -590,15 +590,25 @@ class MpvPlayer(BasePlayer):
             # to allow that version of python to be executed in the mpv subprocess.
             if isMacOS():
                 try:
-                    pythonLibs = subprocess.check_output(['/usr/bin/python', '-E', '-c',
+                    env['PATH'] = '/usr/local/bin:/usr/bin'
+                    ytdl_path = subprocess.check_output(['which', 'youtube-dl'], text=True, env=env).rstrip('\n')
+                    with open(ytdl_path, 'rb') as f:
+                        ytdl_shebang = f.readline()
+                    ytdl_python = ytdl_shebang.decode('utf-8').lstrip('!#').rstrip('\n')
+                    if '/usr/bin/env' in ytdl_python:
+                        python_name = ytdl_python.split(' ')[1]
+                        python_executable = subprocess.check_output(['which', python_name], text=True, env=env).rstrip('\n')
+                    else:
+                        python_executable = ytdl_python
+                    pythonLibs = subprocess.check_output([python_executable, '-E', '-c',
                                                           'import sys; print(sys.path)'],
                                                           text=True, env=dict())
                     pythonLibs = ast.literal_eval(pythonLibs)
                     pythonPath = ':'.join(pythonLibs[1:])
-                except:
+                except Exception as e:
                     pythonPath = None
                 if pythonPath is not None:
-                    env['PATH'] = '/usr/bin:/usr/local/bin'
+                    env['PATH'] = python_executable + ':' + env['PATH']
                     env['PYTHONPATH'] = pythonPath
             try:
                 socket = self.mpv_arguments.get('input-ipc-server')

--- a/syncplay/vendor/python_mpv_jsonipc/python_mpv_jsonipc.py
+++ b/syncplay/vendor/python_mpv_jsonipc/python_mpv_jsonipc.py
@@ -211,7 +211,7 @@ class MPVProcess:
         self._start_process(ipc_socket, args, env=env)
 
     def _start_process(self, ipc_socket, args, env):
-        self.process = subprocess.Popen(args)
+        self.process = subprocess.Popen(args, env=env)
         ipc_exists = False
         for _ in range(100): # Give MPV 10 seconds to start.
             time.sleep(0.1)


### PR DESCRIPTION
This is a follow-up to #279. In principle, this issue should have been solved in https://github.com/Syncplay/syncplay/commit/c07206c18992c1dca401b30a01b9f0fe54a71df5 and #360. However, a mixture of changes in the way Homebrew installs `youtube-dl`, plus a mistake in which the environment was (not) transferred to the relevant subprocess, still caused it to show up in 1.6.7.

This PR re-enables the environment patching on macOS and, additionally, slightly modifies how the environment is patched to make this functional also on the arm64 architecture. Credits to @cordelac for having tested this on their machine.

Please test if this affects running mpv on Windows and Linux in any way before merging.

Closes: #379 