### PR TITLE
Move GUI dependencies to setup.py extra

### DIFF
--- a/ci/appimage-script.sh
+++ b/ci/appimage-script.sh
@@ -101,7 +101,7 @@ mv pl.syncplay.syncplay.appdata.xml AppDir/usr/share/metainfo/
 cp "$REPO_ROOT"/syncplay/resources/syncplay.desktop ./pl.syncplay.syncplay.desktop
 
 #export CONDA_PACKAGES="Pillow"
-export PIP_REQUIREMENTS="."
+export PIP_REQUIREMENTS=".[gui]"
 export PIP_WORKDIR="$REPO_ROOT"
 export VERSION="$(cat $REPO_ROOT/syncplay/__init__.py | awk '/version/ {gsub("\047", "", $3); print $NF}')"
 export OUTPUT=Syncplay-$VERSION-x86_64.AppImage

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ def read(fname):
     with open(fname, 'r') as f:
         return f.read()
 
-installRequirements = read('requirements.txt').splitlines() +\
-                        read('requirements_gui.txt').splitlines()
+installRequirements = read('requirements.txt').splitlines()
+guiRequirements = read('requirements_gui.txt').splitlines()
 
 setuptools.setup(
     name="syncplay",
@@ -27,13 +27,16 @@ setuptools.setup(
     download_url=projectURL + 'download/',
     packages=setuptools.find_packages(),
     install_requires=installRequirements,
+    extras_require={
+        'gui': guiRequirements,
+    },
     python_requires=">=3.4",
     entry_points={
         'console_scripts': [
             'syncplay-server = syncplay.ep_server:main',
         ],
         'gui_scripts': [
-            'syncplay = syncplay.ep_client:main',
+            'syncplay = syncplay.ep_client:main [gui]',
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
I wanted to install Syncplay with pip to make use of the syncplay-server entry point. However, when I did, I noticed that setup.py pulls in PySide2 as `install_requires` unconditionally, making that avenue of install undesirable when I only want to run the server in that specific environment. Therefore, I have moved PySide2 to a new `gui` extra in setup.py, so Syncplay can be install by pip without pulling it in.

I have updated the AppImage build script to account for this change, but I haven't been able to find if the installation as a package is used anywhere else. While I did verify that the AppImage still works with the updated build script, I was unable to test the other platforms as I don't have machines for those available right now.