### PR TITLE
Allow playlists to be played from network

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -569,7 +569,8 @@ class SyncplayClient(object):
         return False
 
     def openFile(self, filePath, resetPosition=False, fromUser=False):
-        if fromUser and filePath.endswith(".txt") or filePath.endswith(".m3u") or filePath.endswith(".m3u8"):
+        if not (filePath.startswith("http://") or filePath.startswith("https://"))\
+                and ((fromUser and filePath.endswith(".txt")) or filePath.endswith(".m3u") or filePath.endswith(".m3u8")):
             self.playlist.loadPlaylistFromFile(filePath, resetPosition)
             return
 


### PR DESCRIPTION
`.m3u`, `.m3u8` (and probably txts as well) are frequently hosted on the web for TV stations, videos, and other media.

This PR checks if the "file path" starts with `http://` or `https://`, and, if so, does not try to load those 'files' from filesystem.

Previously syncplay would not be able to load videos from the internet through the `File > Open media stream URL` menu as it'd try to load them from the FS.