### PR TITLE
Added room permanence option to server

### DIFF
--- a/docs/syncplay-server.1
+++ b/docs/syncplay-server.1
@@ -78,6 +78,10 @@ Random string used to generate managed room passwords.
 Path to a file from which motd (Message Of The Day) will be read.
 
 .TP
+.B \-\-rooms\-dir [directory]
+Path to a directory from where room data will be written to and read from. This will enable rooms to persist without watchers and through restarts. Will not work if using \fB--isolate-rooms\fP.
+
+.TP
 .B \-\-max\-chat\-message\-length [maxChatMessageLength]
 Maximum number of characters in one chat message (default is 150).
 

--- a/docs/syncplay-server.1
+++ b/docs/syncplay-server.1
@@ -79,7 +79,11 @@ Path to a file from which motd (Message Of The Day) will be read.
 
 .TP
 .B \-\-rooms\-dir [directory]
-Path to a directory from where room data will be written to and read from. This will enable rooms to persist without watchers and through restarts. Will not work if using \fB--isolate-rooms\fP.
+Path to a directory from where room data will be written to and read from. This will enable rooms to persist without watchers and through restarts. Will not work if using \fB\-\-isolate\-rooms\fP.
+
+.TP
+.B \-\-rooms\-timer [directory]
+Requires \fB\-\-rooms\-timer\fP. Time in seconds that rooms will persist without users. \fB0\fP disables the timer, meaning rooms persist permanently.
 
 .TP
 .B \-\-max\-chat\-message\-length [maxChatMessageLength]

--- a/syncplay/ep_server.py
+++ b/syncplay/ep_server.py
@@ -35,6 +35,7 @@ def main():
         args.password,
         args.motd_file,
         args.rooms_dir,
+        args.rooms_timer,
         args.isolate_rooms,
         args.salt,
         args.disable_ready,

--- a/syncplay/ep_server.py
+++ b/syncplay/ep_server.py
@@ -34,6 +34,7 @@ def main():
         args.port,
         args.password,
         args.motd_file,
+        args.rooms_dir,
         args.isolate_rooms,
         args.salt,
         args.disable_ready,

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -473,6 +473,7 @@ de = {
     "server-disable-ready-argument": "Bereitschaftsfeature deaktivieren",
     "server-motd-argument": "Pfad zur Datei, von der die Nachricht des Tages geladen wird",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "Soll Chat deaktiviert werden?",
     "server-chat-maxchars-argument": "Maximale Zeichenzahl in einer Chatnachricht (Standard ist {})",
     "server-maxusernamelength-argument": "Maximale Zeichenzahl in einem Benutzernamen (Standard ist {})",

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -472,6 +472,7 @@ de = {
     "server-salt-argument": "zufällige Zeichenkette, die zur Erstellung von Passwörtern verwendet wird",
     "server-disable-ready-argument": "Bereitschaftsfeature deaktivieren",
     "server-motd-argument": "Pfad zur Datei, von der die Nachricht des Tages geladen wird",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "Soll Chat deaktiviert werden?",
     "server-chat-maxchars-argument": "Maximale Zeichenzahl in einer Chatnachricht (Standard ist {})",
     "server-maxusernamelength-argument": "Maximale Zeichenzahl in einem Benutzernamen (Standard ist {})",

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -473,6 +473,7 @@ en = {
     "server-salt-argument": "random string used to generate managed room passwords",
     "server-disable-ready-argument": "disable readiness feature",
     "server-motd-argument": "path to file from which motd will be fetched",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts",
     "server-chat-argument": "Should chat be disabled?",
     "server-chat-maxchars-argument": "Maximum number of characters in a chat message (default is {})", # Default number of characters
     "server-maxusernamelength-argument": "Maximum number of characters in a username (default is {})",

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -474,6 +474,7 @@ en = {
     "server-disable-ready-argument": "disable readiness feature",
     "server-motd-argument": "path to file from which motd will be fetched",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts",
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning",
     "server-chat-argument": "Should chat be disabled?",
     "server-chat-maxchars-argument": "Maximum number of characters in a chat message (default is {})", # Default number of characters
     "server-maxusernamelength-argument": "Maximum number of characters in a username (default is {})",

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -472,6 +472,7 @@ es = {
     "server-salt-argument": "cadena aleatoria utilizada para generar contraseñas de salas administradas",
     "server-disable-ready-argument": "deshabilitar la función de preparación",
     "server-motd-argument": "ruta al archivo del cual se obtendrá el texto motd",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "¿Debería deshabilitarse el chat?",
     "server-chat-maxchars-argument": "Número máximo de caracteres en un mensaje de chat (el valor predeterminado es {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximo de caracteres para el nombre de usuario (el valor predeterminado es {})",

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -473,6 +473,7 @@ es = {
     "server-disable-ready-argument": "deshabilitar la función de preparación",
     "server-motd-argument": "ruta al archivo del cual se obtendrá el texto motd",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "¿Debería deshabilitarse el chat?",
     "server-chat-maxchars-argument": "Número máximo de caracteres en un mensaje de chat (el valor predeterminado es {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximo de caracteres para el nombre de usuario (el valor predeterminado es {})",

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -472,6 +472,7 @@ it = {
     "server-salt-argument": "usare stringhe casuali per generare le password delle stanze gestite",
     "server-disable-ready-argument": "disabilita la funzionalità \"pronto\"",
     "server-motd-argument": "percorso del file da cui verrà letto il messaggio del giorno",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "abilita o disabilita la chat",
     "server-chat-maxchars-argument": "Numero massimo di caratteri in un messaggio di chat (default è {})", # Default number of characters
     "server-maxusernamelength-argument": "Numero massimo di caratteri in un nome utente (default è {})",

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -473,6 +473,7 @@ it = {
     "server-disable-ready-argument": "disabilita la funzionalità \"pronto\"",
     "server-motd-argument": "percorso del file da cui verrà letto il messaggio del giorno",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "abilita o disabilita la chat",
     "server-chat-maxchars-argument": "Numero massimo di caratteri in un messaggio di chat (default è {})", # Default number of characters
     "server-maxusernamelength-argument": "Numero massimo di caratteri in un nome utente (default è {})",

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -473,6 +473,7 @@ pt_BR = {
     "server-salt-argument": "string aleatória utilizada para gerar senhas de salas gerenciadas",
     "server-disable-ready-argument": "desativar recurso de prontidão",
     "server-motd-argument": "caminho para o arquivo o qual o motd será obtido",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "O chat deve ser desativado?",
     "server-chat-maxchars-argument": "Número máximo de caracteres numa mensagem do chat (o padrão é {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximos de caracteres num nome de usuário (o padrão é {})",

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -474,6 +474,7 @@ pt_BR = {
     "server-disable-ready-argument": "desativar recurso de prontidão",
     "server-motd-argument": "caminho para o arquivo o qual o motd será obtido",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "O chat deve ser desativado?",
     "server-chat-maxchars-argument": "Número máximo de caracteres numa mensagem do chat (o padrão é {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximos de caracteres num nome de usuário (o padrão é {})",

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -473,6 +473,7 @@ pt_PT = {
     "server-disable-ready-argument": "desativar recurso de prontidão",
     "server-motd-argument": "caminho para o arquivo o qual o motd será obtido",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "O chat deve ser desativado?",
     "server-chat-maxchars-argument": "Número máximo de caracteres numa mensagem do chat (o padrão é {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximos de caracteres num nome de utilizador (o padrão é {})",

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -472,6 +472,7 @@ pt_PT = {
     "server-salt-argument": "string aleatória utilizada para gerar senhas de salas gerenciadas",
     "server-disable-ready-argument": "desativar recurso de prontidão",
     "server-motd-argument": "caminho para o arquivo o qual o motd será obtido",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "O chat deve ser desativado?",
     "server-chat-maxchars-argument": "Número máximo de caracteres numa mensagem do chat (o padrão é {})", # Default number of characters
     "server-maxusernamelength-argument": "Número máximos de caracteres num nome de utilizador (o padrão é {})",

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -470,6 +470,7 @@ ru = {
     "server-disable-ready-argument": "отключить статусы готов/не готов",
     "server-motd-argument": "путь к файлу, из которого будет извлекаться MOTD-сообщение",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "Должен ли чат быть отключён?",
     "server-chat-maxchars-argument": "Максимальное число символов в сообщениях в чате (по умолчанию {})",
     "server-maxusernamelength-argument": "Максимальное число символов в именах пользователей (по умолчанию {})",

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -469,6 +469,7 @@ ru = {
     "server-salt-argument": "генерировать пароли к управляемым комнатам на основании указанной строки (соли)",
     "server-disable-ready-argument": "отключить статусы готов/не готов",
     "server-motd-argument": "путь к файлу, из которого будет извлекаться MOTD-сообщение",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "Должен ли чат быть отключён?",
     "server-chat-maxchars-argument": "Максимальное число символов в сообщениях в чате (по умолчанию {})",
     "server-maxusernamelength-argument": "Максимальное число символов в именах пользователей (по умолчанию {})",

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -473,6 +473,7 @@ tr = {
     "server-salt-argument": "yönetilen oda şifreleri oluşturmak için kullanılan rastgele dize",
     "server-disable-ready-argument": "hazır olma özelliğini devre dışı bırak",
     "server-motd-argument": "motd alınacak dosyanın yolu",
+    "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
     "server-chat-argument": "Sohbet devre dışı bırakılmalı mı?",
     "server-chat-maxchars-argument": "Bir sohbet mesajındaki maksimum karakter sayısı (varsayılan: {})", # Default number of characters
     "server-maxusernamelength-argument": "Bir kullanıcı adındaki maksimum karakter sayısı (varsayılan {})",

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -474,6 +474,7 @@ tr = {
     "server-disable-ready-argument": "hazır olma özelliğini devre dışı bırak",
     "server-motd-argument": "motd alınacak dosyanın yolu",
     "server-rooms-argument": "path to directory to store/fetch room data. Enables rooms to persist without watchers and through restarts", # TODO: Translate
+    "server-timer-argument": "time in seconds before a persistent room with no watchers is pruned. 0 disables pruning", # TODO: Translate
     "server-chat-argument": "Sohbet devre dışı bırakılmalı mı?",
     "server-chat-maxchars-argument": "Bir sohbet mesajındaki maksimum karakter sayısı (varsayılan: {})", # Default number of characters
     "server-maxusernamelength-argument": "Bir kullanıcı adındaki maksimum karakter sayısı (varsayılan {})",

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -421,11 +421,17 @@ class Room(object):
     def __str__(self, *args, **kwargs):
         return self.getName()
 
+    def roomsCanPersist(self):
+        return self._roomsDir is not None
+
+    def isPermanent(self):
+        return self.roomsCanPersist()
+
     def sanitizeFilename(self, filename, blacklist="<>:/\\|?*\"", placeholder="_"):
         return ''.join([c if c not in blacklist and ord(c) >= 32 else placeholder for c in filename])
 
     def writeToFile(self):
-        if self._roomsDir is None:
+        if not self.isPermanent():
             return
         if len(self._playlist) == 0:
             try:
@@ -487,7 +493,7 @@ class Room(object):
         return list(self._watchers.values())
 
     def addWatcher(self, watcher):
-        if self._watchers or self._roomsDir is not None:
+        if self._watchers or self.isPermanent():
             watcher.setPosition(self.getPosition())
         self._watchers[watcher.getName()] = watcher
         watcher.setRoom(self)
@@ -497,7 +503,7 @@ class Room(object):
             return
         del self._watchers[watcher.getName()]
         watcher.setRoom(None)
-        if not self._watchers and self._roomsDir is None:
+        if not self._watchers and not self.isPermanent():
             self._position = 0
         self.writeToFile()
 

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -438,9 +438,10 @@ class Room(object):
     def writeToFile(self):
         if not self.isPermanent():
             return
+        filename = os.path.join(self._roomsDir, self.sanitizeFilename(self._name)+'.room')
         if len(self._playlist) == 0:
             try:
-                os.remove(os.path.join(self._roomsDir, self.sanitizeFilename(self._name)+'.room'))
+                os.remove(filename)
             except Exception:
                 pass
             return
@@ -450,7 +451,7 @@ class Room(object):
         data['playlistIndex'] = self._playlistIndex
         data['position'] = self._position
         data['lastSavedUpdate'] = self._lastSavedUpdate
-        with open(os.path.join(self._roomsDir, self.sanitizeFilename(self._name)+'.room'), "w") as outfile:
+        with open(filename, "w") as outfile:
             json.dump(data, outfile)
 
     def loadFromFile(self, filename):

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -475,6 +475,7 @@ class Room(object):
         for watcher in self._watchers.values():
             watcher.setPosition(position)
             self._setBy = setBy
+        self.writeToFile()
 
     def isPlaying(self):
         return self._playState == self.STATE_PLAYING
@@ -486,7 +487,7 @@ class Room(object):
         return list(self._watchers.values())
 
     def addWatcher(self, watcher):
-        if self._watchers:
+        if self._watchers or self._roomsDir is not None:
             watcher.setPosition(self.getPosition())
         self._watchers[watcher.getName()] = watcher
         watcher.setRoom(self)
@@ -496,8 +497,9 @@ class Room(object):
             return
         del self._watchers[watcher.getName()]
         watcher.setRoom(None)
-        if not self._watchers:
+        if not self._watchers and self._roomsDir is None:
             self._position = 0
+        self.writeToFile()
 
     def isEmpty(self):
         return not bool(self._watchers)

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -41,7 +41,7 @@ class SyncFactory(Factory):
             print(getMessage("no-salt-notification").format(salt))
         self._salt = salt
         self._motdFilePath = motdFilePath
-        self._roomsDirPath = roomsDirPath if os.path.isdir(roomsDirPath) else None
+        self._roomsDirPath = roomsDirPath if roomsDirPath is not None and os.path.isdir(roomsDirPath) else None
         self.disableReady = disableReady
         self.disableChat = disableChat
         self.maxChatMessageLength = maxChatMessageLength if maxChatMessageLength is not None else constants.MAX_CHAT_MESSAGE_LENGTH

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -327,6 +327,7 @@ class RoomManager(object):
                         roomName = truncateText(room.getName(), constants.MAX_ROOM_NAME_LENGTH)
                         if len(room.getPlaylist()) == 0 or room.isStale(self._timer):
                             os.remove(os.path.join(root, file))
+                            del room
                         else:
                             self._rooms[roomName] = room
 

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -421,6 +421,9 @@ class Room(object):
     def __str__(self, *args, **kwargs):
         return self.getName()
 
+    def sanitizeFilename(self, filename, blacklist="<>:/\\|?*\"", placeholder="_"):
+        return ''.join([c if c not in blacklist and ord(c) >= 32 else placeholder for c in filename])
+
     def writeToFile(self):
         if self._roomsDir is None:
             return
@@ -431,7 +434,7 @@ class Room(object):
         data['playlist'] = self._playlist
         data['playlistIndex'] = self._playlistIndex
         data['position'] = self._position
-        with open(os.path.join(self._roomsDir, self._name+'.room'), "w") as outfile:
+        with open(os.path.join(self._roomsDir, self.sanitizeFilename(self._name)+'.room'), "w") as outfile:
             json.dump(data, outfile)
 
     def loadFromFile(self, filename):

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -428,6 +428,10 @@ class Room(object):
         if self._roomsDir is None:
             return
         if len(self._playlist) == 0:
+            try:
+                os.remove(os.path.join(self._roomsDir, self.sanitizeFilename(self._name)+'.room'))
+            except Exception:
+                pass
             return
         data = {}
         data['name'] = self._name


### PR DESCRIPTION
Added the **--rooms-dir [directory]** option to the server.
This allows the specifying of a directory to be used to read and write room data in order for playlists to persist permanently, regardless of every watcher leaving or the server restarting.
The behavior won't take place if the directory does not exist, or if the **--isolate-rooms** option is enabled.