### PR TITLE
Trusted Domains: Allow trusting a domain regardless of HTTP basic auth credentials

### DIFF
--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -339,6 +339,6 @@ SYNCPLAY_DOWNLOAD_URL = "https://syncplay.pl/download/"
 SYNCPLAY_PUBLIC_SERVER_LIST_URL = "https://syncplay.pl/listpublicservers?{}"  # Params
 
 DEFAULT_TRUSTED_DOMAINS = ["youtube.com", "youtu.be"]
-TRUSTABLE_WEB_PROTOCOLS = ["http://www.", "https://www.", "http://", "https://"]
+TRUSTABLE_WEB_PROTOCOLS = ["http", "https"]
 
 PRIVATE_FILE_FIELDS = ["path"]

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -731,7 +731,8 @@ class MainWindow(QtWidgets.QMainWindow):
                                lambda: utils.open_system_file_browser(pathFound))
             if self._syncplayClient.isUntrustedTrustableURI(firstFile):
                 domain = utils.getDomainFromURL(firstFile)
-                menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
+                if domain:
+                    menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
             menu.addAction(QtGui.QPixmap(resourcespath + "delete.png"), getMessage("removefromplaylist-menu-label"), lambda: self.deleteSelectedPlaylistItems())
             menu.addSeparator()
         menu.addAction(QtGui.QPixmap(resourcespath + "arrow_switch.png"), getMessage("shuffleremainingplaylist-menu-label"), lambda: self.shuffleRemainingPlaylist())
@@ -794,7 +795,8 @@ class MainWindow(QtWidgets.QMainWindow):
                         menu.addAction(QtGui.QPixmap(resourcespath + "film_go.png"), getMessage("openusersfile-menu-label").format(shortUsername), lambda: self.openFile(pathFound, resetPosition=False, fromUser=True))
             if self._syncplayClient.isUntrustedTrustableURI(filename):
                 domain = utils.getDomainFromURL(filename)
-                menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
+                if domain:
+                    menu.addAction(QtGui.QPixmap(resourcespath + "shield_add.png"), getMessage("addtrusteddomain-menu-label").format(domain), lambda: self.addTrustedDomain(domain))
 
             if not isURL(filename) and filename != getMessage("nofile-note"):
                 path = self._syncplayClient.fileSwitch.findFilepath(filename)

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -395,12 +395,15 @@ def playlistIsValid(files):
 
 def getDomainFromURL(URL):
     try:
-        URL = URL.split("//")[-1].split("/")[0]
-        if URL.startswith("www."):
-            URL = URL[4:]
-        return URL
-    except:
+        o = urllib.parse.urlparse(URL)
+    except ValueError:
+        # not a URL
         return None
+    if o.hostname is not None and o.hostname.startswith("www."):
+        return o.hostname[4:]
+    else:
+        # may return None if URL does not have domain (invalid url)
+        return o.hostname
 
 
 def open_system_file_browser(path):


### PR DESCRIPTION
**TL;DR:** If you want to trust URIs with credentials in them, you have to add the full thing to the trusted domains: `user:pass@example.com`. This PR makes it so you can just add `example.com`, even when using credentials.

**Long version**
I have the following use-case: I have a webserver that serves videos, but they are protected with HTTP basic authentication. It is possible to embed the credentials in a URL like so:

`https://username:password@example.com/video.mkv`

This URL works, for example, in mpv. I can add this URL in the syncplay playlist and it works fine. But I get the untrusted domain warning and have to click the playlist entry manually. If I add `example.com` to the "trusted domains" in the Advanced menu, I still get the warning. Only if I add `username:password@example.com` to the trusted domains, the warning disappears.

This workaround is not very good because the credentials are saved on disk in the syncplay settings and also the trusted domain entry has to be adjusted if the credentials change.

Therefore, I've rewritten the trusted domain checking code to ignore the credentials. I use `urllib.parse` to make it quite simple and safe.

I have taken care to match the old behavior exactly, except: If someone already uses the workaround above, i.e. already has a domain with basic auth credentials in the trusted domains list, it will no longer match anything. If this exception is undesired, I can easily make it so that trusted domains with embedded credentials are also still matched.

Note that trusted domains can not only be domains, they can also have a path attached, e.g. `example.com/videos`. For these cases, there is another -- IMO unimportant -- difference: The old code only trusts URLs if a trusted domain is a prefix plus a slash. For example:  
Trusted domain `example.com/videos` allows `example.com/videos/wat.mkv` but not `example.com/videoswat.mkv`.  
Trusted domain `example.com/videos/` allows `example.com/videos//wat.mkv` but not `example.com/videos/wat.mkv`.
My new code does not add the extra slash -- each of the two trusted domains above match both given example URLs. I prefer this compared to the old behavior, but I can change it if desired.