### PR TITLE
Add LANG Parameter

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -286,7 +286,16 @@ NSIS_SCRIPT_TEMPLATE = r"""
 
     Call GetSize
     Call DriveSpace
-    Call Language
+
+    $${GetParameters} $$0
+    ClearErrors
+    $${GetOptions} $$0 "/LANG=" $$0
+    $${IfNot} $${Errors}
+    $${AndIf} $$0 <> 0
+      StrCpy $$LANGUAGE $$0
+    $${Else}
+      Call Language
+    $${EndIf}
   FunctionEnd
 
   ;Language selection dialog


### PR DESCRIPTION
If LANG parameter set, don't show language dialog.

Fixes #396 & #358

This can allow fully automatic installation via chocolatey.

Example usage: `.\Syncplay-X.X.X-Setup.exe /S /LANG=1033`