### PR TITLE
Correct persistance argument type

### DIFF
--- a/docs/syncplay-server.1
+++ b/docs/syncplay-server.1
@@ -78,11 +78,11 @@ Random string used to generate managed room passwords.
 Path to a file from which motd (Message Of The Day) will be read.
 
 .TP
-.B \-\-rooms\-db-file [directory]
+.B \-\-rooms\-db-file [file]
 Enables room persistence. Path is to where a database file should be loaded/create where room data will be written to and read from. This will enable rooms to persist without watchers and through restarts. Will not work if using \fB\-\-isolate\-rooms\fP.
 
 .TP
-.B \-\-permanent\-rooms-file [directory]
+.B \-\-permanent\-rooms-file [file]
 Specifies a list of rooms that will still be listed even if their playlist is empty. Path is to where a text file with one room per line. This will require persistent rooms to be enabled.
 
 


### PR DESCRIPTION
The current documentation specifies directories, likely as a result of the original design before use of a database, but the arguments expect files. This simply clarifies the documentation to match the code itself.