### PR TITLE
Fixes converting lines to array

### DIFF
--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -383,7 +383,7 @@ def getListAsMultilineString(pathArray):
 
 
 def convertMultilineStringToList(multilineString):
-    return str.split(multilineString, "\n") if multilineString else ""
+    return str.split(multilineString, "\n") if multilineString else []
 
 
 def playlistIsValid(files):


### PR DESCRIPTION
if condition was false convertMultilineStringToList returned "" instead
of an empty list.