### PR TITLE
Print timestamp when pausing.

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -360,7 +360,7 @@ class SyncplayClient(object):
         self._player.setPaused(True)
         madeChangeOnPlayer = True
         if (self.lastLeftTime < time.time() - constants.OSD_DURATION) or hideFromOSD == True:
-            self.ui.showMessage(getMessage("pause-notification").format(setBy, self.getGlobalPosition()), hideFromOSD)
+            self.ui.showMessage(getMessage("pause-notification").format(setBy, utils.formatTime(self.getGlobalPosition())), hideFromOSD)
         else:
             self.ui.showMessage(getMessage("left-paused-notification").format(self.lastLeftUser, setBy), hideFromOSD)
         return madeChangeOnPlayer

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -360,7 +360,7 @@ class SyncplayClient(object):
         self._player.setPaused(True)
         madeChangeOnPlayer = True
         if (self.lastLeftTime < time.time() - constants.OSD_DURATION) or hideFromOSD == True:
-            self.ui.showMessage(getMessage("pause-notification").format(setBy), hideFromOSD)
+            self.ui.showMessage(getMessage("pause-notification").format(setBy, self.getGlobalPosition()), hideFromOSD)
         else:
             self.ui.showMessage(getMessage("left-paused-notification").format(self.lastLeftUser, setBy), hideFromOSD)
         return madeChangeOnPlayer

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -23,7 +23,7 @@ de = {
     "slowdown-notification": "Verlangsamt wegen Zeitdifferenz mit {}",  # User
     "revert-notification": "Normalgeschwindigkeit",
 
-    "pause-notification": "{} pausierte",  # User
+    "pause-notification": "{} pausierte ({})",  # User
     "unpause-notification": "{} startete",  # User
     "seek-notification": "{} sprang von {} nach {}",  # User, from time, to time
 

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -23,7 +23,7 @@ en = {
     "slowdown-notification": "Slowing down due to time difference with {}",  # User
     "revert-notification": "Reverting speed back to normal",
 
-    "pause-notification": "{} paused",  # User
+    "pause-notification": "{} paused at {}",  # User
     "unpause-notification": "{} unpaused",  # User
     "seek-notification": "{} jumped from {} to {}",  # User, from time, to time
 

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -23,7 +23,7 @@ en = {
     "slowdown-notification": "Slowing down due to time difference with {}",  # User
     "revert-notification": "Reverting speed back to normal",
 
-    "pause-notification": "{} paused at {}",  # User
+    "pause-notification": "{} paused ({})",  # User
     "unpause-notification": "{} unpaused",  # User
     "seek-notification": "{} jumped from {} to {}",  # User, from time, to time
 

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -23,7 +23,7 @@ es = {
     "slowdown-notification": "Ralentizando debido a diferencia de tiempo con {}",  # User
     "revert-notification": "Revirtiendo a la velocidad normal",
 
-    "pause-notification": "{} pausado",  # User
+    "pause-notification": "{} pausado ({})",  # User
     "unpause-notification": "{} resumido",  # User
     "seek-notification": "{} saltó desde {} hasta {}",  # User, from time, to time
 

--- a/syncplay/messages_fr.py
+++ b/syncplay/messages_fr.py
@@ -23,7 +23,7 @@ fr = {
     "slowdown-notification": "Ralentissement dû au décalage de temps avec {}",  # User
     "revert-notification": "Retour à la vitesse normale",
 
-    "pause-notification": "{} en pause",  # User
+    "pause-notification": "{} en pause ({})",  # User
     "unpause-notification": "{} non suspendu",  # User
     "seek-notification": "{} est passé de {} à {}",  # User, from time, to time
 

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -23,7 +23,7 @@ it = {
     "slowdown-notification": "Rallento a causa della differenza temporale con {}",  # User
     "revert-notification": "Ripristino la velocità di riproduzione normale",
 
-    "pause-notification": "{} ha messo in pausa",  # User
+    "pause-notification": "{} ha messo in pausa ({})",  # User
     "unpause-notification": "{} ha ripreso la riproduzione",  # User
     "seek-notification": "{} è passato da {} a {}",  # User, from time, to time
 

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -23,7 +23,7 @@ pt_BR = {
     "slowdown-notification": "Diminuindo a velocidade devido à diferença de tempo com {}",  # User
     "revert-notification": "Revertendo velocidade ao normal",
 
-    "pause-notification": "{} pausou",  # User
+    "pause-notification": "{} pausou ({})",  # User
     "unpause-notification": "{} despausou",  # User
     "seek-notification": "{} saltou de {} para {}",  # User, from time, to time
 

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -23,7 +23,7 @@ pt_PT = {
     "slowdown-notification": "Diminuindo a velocidade devido à diferença de tempo com {}",  # User
     "revert-notification": "Revertendo velocidade ao normal",
 
-    "pause-notification": "{} pausou",  # User
+    "pause-notification": "{} pausou ({})",  # User
     "unpause-notification": "{} despausou",  # User
     "seek-notification": "{} saltou de {} para {}",  # User, from time, to time
 

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -23,7 +23,7 @@ ru = {
     "slowdown-notification": "Воспроизведение замедлено из-за разницы во времени с {}",  # User
     "revert-notification": "Возвращаемся к нормальной скорости воспроизведения",
 
-    "pause-notification": "{} приостановил воспроизведение",  # User
+    "pause-notification": "{} приостановил воспроизведение ({})",  # User
     "unpause-notification": "{} возобновил воспроизведение",  # User
     "seek-notification": "{} перемотал с {} на {}",  # User, from time, to time
 

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -23,7 +23,7 @@ tr = {
     "slowdown-notification": "{} ile zaman farkı nedeniyele nedeniyle yavaşlıyor",  # User
     "revert-notification": "Hızı normale döndürülüyor",
 
-    "pause-notification": "{} duraklattı",  # User
+    "pause-notification": "{} duraklattı ({})",  # User
     "unpause-notification": "{} devam ettirdi",  # User
     "seek-notification": "{}, {} konumundan {} konumuna atladı",  # User, from time, to time
 

--- a/syncplay/messages_zh_CN.py
+++ b/syncplay/messages_zh_CN.py
@@ -23,7 +23,7 @@ zh_CN = {
     "slowdown-notification": "与{}不同步，正在慢速播放",  # User
     "revert-notification": "播放速度恢复一倍速",
 
-    "pause-notification": "{}暂停了",  # User
+    "pause-notification": "{}暂停了 ({})",  # User
     "unpause-notification": "{}重新开始播放",  # User
     "seek-notification": "{}从{}跳转到{}",  # User, from time, to time
 


### PR DESCRIPTION
I would like to use Syncplay to watch a movie with a friend for a podcast where we watch together, pause to talk about things, and assemble it into a slide slow later. Syncplay printing when the media was paused in its log would help with this immensely. 