### PR TITLE
Refactor: Move installer text to messages_ files

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -27,7 +27,7 @@ except ImportError:
     from py2exe.distutils_buildexe import py2exe
 
 import syncplay
-from syncplay.messages import getMissingStrings
+from syncplay.messages import getMissingStrings, getMessage, getLanguages
 
 missingStrings = getMissingStrings()
 if missingStrings is not None and missingStrings != "":
@@ -52,23 +52,64 @@ NSIS_COMPILE = get_nsis_path()
 
 OUT_DIR = "syncplay_v{}".format(syncplay.version)
 SETUP_SCRIPT_PATH = "syncplay_setup.nsi"
+
+languages = getLanguages()
+
+def getLangTagFromNLF(lang):
+    return "LANG_" + getMessage("installer-language-file", lang).upper().replace(".NLF","").replace("_","")
+
+
+# Load languages
+loadLanguageFileString = ""
+for lang in languages:
+    lineToAdd = "LoadLanguageFile \"$${{NSISDIR}}\\Contrib\\Language files\\{}\"".format(getMessage("installer-language-file", lang))
+    loadLanguageFileString = loadLanguageFileString + "\r\n" + lineToAdd
+
+# Add Version Keys
+versionKeysString = ""
+for lang in languages:
+    languageIdent = getLangTagFromNLF(lang)
+    lineToAdd = r"""  VIAddVersionKey /LANG=$${LANG_IDENT} "ProductName" "Syncplay"
+  VIAddVersionKey /LANG=$${LANG_IDENT} "FileVersion" "$version.0"
+  VIAddVersionKey /LANG=$${LANG_IDENT} "LegalCopyright" "Syncplay"
+  VIAddVersionKey /LANG=$${LANG_IDENT} "FileDescription" "Syncplay"
+  """.replace("LANG_IDENT", languageIdent)
+    versionKeysString = versionKeysString + "\r\n" + lineToAdd
+
+# Add Language Strings
+languageString = ""
+for lang in languages:
+    languageIdent = getLangTagFromNLF(lang)
+
+    # dict_dict = {'dict1':dict1, 'dicta':dicta, 'dict666':dict666}
+    #
+    # for name,dict_ in dict_dict.items():
+    #     print 'the name of the dictionary is ', name
+    #     print 'the dictionary looks like ', dict_
+
+    langStringDict = {
+        # "[NSIS key name]": "[messages_*.py key name]"
+        "SyncplayLanguage": "LANGUAGE-TAG",
+        "Associate": "installer-associate",
+        "Shortcut": "installer-shortcut",
+        "StartMenu": "installer-start-menu",
+        "Desktop": "installer-desktop",
+        "QuickLaunchBar": "installer-quick-launch-bar",
+        "AutomaticUpdates": "installer-automatic-updates",
+        "UninstConfig": "installer-uninstall-configuration"
+    }
+    for nsisKey, messageKey in langStringDict.items():
+        nsisValue = getMessage(messageKey, lang)
+        lineToAdd = "  LangString ^" + nsisKey + " $${" + languageIdent + "} \"" + nsisValue + "\""
+        languageString = languageString + "\r\n" + lineToAdd
+    languageString = languageString + "\r\n"
+
 NSIS_SCRIPT_TEMPLATE = r"""
   !include LogicLib.nsh
   !include nsDialogs.nsh
   !include FileFunc.nsh
 
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\English.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Esperanto.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Polish.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Russian.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\German.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Italian.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Spanish.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\PortugueseBR.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Portuguese.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\Turkish.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\French.nlf"
-  LoadLanguageFile "$${NSISDIR}\Contrib\Language files\SimpChinese.nlf"
+""" + loadLanguageFileString + r"""
  
   Unicode true
 
@@ -82,168 +123,8 @@ NSIS_SCRIPT_TEMPLATE = r"""
   SetCompressor /SOLID lzma
 
   VIProductVersion "$version.0"
-  VIAddVersionKey /LANG=$${LANG_ENGLISH} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ENGLISH} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_ENGLISH} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ENGLISH} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_ESPERANTO} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ESPERANTO} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_ESPERANTO} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ESPERANTO} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_POLISH} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_POLISH} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_POLISH} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_POLISH} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_RUSSIAN} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_RUSSIAN} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_RUSSIAN} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_RUSSIAN} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_ITALIAN} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ITALIAN} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_ITALIAN} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_ITALIAN} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_SPANISH} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_SPANISH} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_SPANISH} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_SPANISH} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESEBR} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESEBR} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESEBR} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESEBR} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESE} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESE} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESE} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_PORTUGUESE} "FileDescription" "Syncplay"
-
-  VIAddVersionKey /LANG=$${LANG_TURKISH} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_TURKISH} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_TURKISH} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_TURKISH} "FileDescription" "Syncplay"
   
-  VIAddVersionKey /LANG=$${LANG_FRENCH} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_FRENCH} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_FRENCH} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_FRENCH} "FileDescription" "Syncplay"
-  
-  VIAddVersionKey /LANG=$${LANG_SIMPCHINESE} "ProductName" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_SIMPCHINESE} "FileVersion" "$version.0"
-  VIAddVersionKey /LANG=$${LANG_SIMPCHINESE} "LegalCopyright" "Syncplay"
-  VIAddVersionKey /LANG=$${LANG_SIMPCHINESE} "FileDescription" "Syncplay"
-
-  LangString ^SyncplayLanguage $${LANG_ENGLISH} "en"
-  LangString ^Associate $${LANG_ENGLISH} "Associate Syncplay with multimedia files."
-  LangString ^Shortcut $${LANG_ENGLISH} "Create Shortcuts in following locations:"
-  LangString ^StartMenu $${LANG_ENGLISH} "Start Menu"
-  LangString ^Desktop $${LANG_ENGLISH} "Desktop"
-  LangString ^QuickLaunchBar $${LANG_ENGLISH} "Quick Launch Bar"
-  LangString ^AutomaticUpdates $${LANG_ENGLISH} "Check for updates automatically"
-  LangString ^UninstConfig $${LANG_ENGLISH} "Delete configuration file."
-
-  LangString ^SyncplayLanguage $${LANG_ESPERANTO} "eo"
-  LangString ^Associate $${LANG_ESPERANTO} "Asocii vidaŭdaĵajn dosierojn kun Syncplay."
-  LangString ^Shortcut $${LANG_ESPERANTO} "Krei mallongigojn en la jenaj lokoj:"
-  LangString ^StartMenu $${LANG_ESPERANTO} "Start-menuo"
-  LangString ^Desktop $${LANG_ESPERANTO} "Labortablo"
-  LangString ^QuickLaunchBar $${LANG_ESPERANTO} "Tujbreto"
-  LangString ^AutomaticUpdates $${LANG_ESPERANTO} "Kontroli ĝisdatigojn memage"
-  LangString ^UninstConfig $${LANG_ESPERANTO} "Forigi dosieron kun agordaro."
-
-  LangString ^SyncplayLanguage $${LANG_POLISH} "pl"
-  LangString ^Associate $${LANG_POLISH} "Skojarz Syncplaya z multimediami"
-  LangString ^Shortcut $${LANG_POLISH} "Utworz skroty w nastepujacych miejscach:"
-  LangString ^StartMenu $${LANG_POLISH} "Menu Start"
-  LangString ^Desktop $${LANG_POLISH} "Pulpit"
-  LangString ^QuickLaunchBar $${LANG_POLISH} "Pasek szybkiego uruchamiania"
-  LangString ^UninstConfig $${LANG_POLISH} "Usun plik konfiguracyjny."
-
-  LangString ^SyncplayLanguage $${LANG_RUSSIAN} "ru"
-  LangString ^Associate $${LANG_RUSSIAN} "Ассоциировать Syncplay с видеофайлами"
-  LangString ^Shortcut $${LANG_RUSSIAN} "Создать ярлыки:"
-  LangString ^StartMenu $${LANG_RUSSIAN} "в меню Пуск"
-  LangString ^Desktop $${LANG_RUSSIAN} "на рабочем столе"
-  LangString ^QuickLaunchBar $${LANG_RUSSIAN} "в меню быстрого запуска"
-  LangString ^AutomaticUpdates $${LANG_RUSSIAN} "Проверять обновления автоматически"; TODO: Confirm Russian translation ("Check for updates automatically")
-  LangString ^UninstConfig $${LANG_RUSSIAN} "Удалить файл настроек."
-
-  LangString ^SyncplayLanguage $${LANG_GERMAN} "de"
-  LangString ^Associate $${LANG_GERMAN} "Syncplay als Standardprogramm für Multimedia-Dateien verwenden."
-  LangString ^Shortcut $${LANG_GERMAN} "Erstelle Verknüpfungen an folgenden Orten:"
-  LangString ^StartMenu $${LANG_GERMAN} "Startmenü"
-  LangString ^Desktop $${LANG_GERMAN} "Desktop"
-  LangString ^QuickLaunchBar $${LANG_GERMAN} "Schnellstartleiste"
-  LangString ^AutomaticUpdates $${LANG_GERMAN} "Automatisch nach Updates suchen";
-  LangString ^UninstConfig $${LANG_GERMAN} "Konfigurationsdatei löschen."
-
-  LangString ^SyncplayLanguage $${LANG_ITALIAN} "it"
-  LangString ^Associate $${LANG_ITALIAN} "Associa Syncplay con i file multimediali."
-  LangString ^Shortcut $${LANG_ITALIAN} "Crea i collegamenti nei percorsi seguenti:"
-  LangString ^StartMenu $${LANG_ITALIAN} "Menu Start"
-  LangString ^Desktop $${LANG_ITALIAN} "Desktop"
-  LangString ^QuickLaunchBar $${LANG_ITALIAN} "Barra di avvio rapido"
-  LangString ^AutomaticUpdates $${LANG_ITALIAN} "Controllo automatico degli aggiornamenti"
-  LangString ^UninstConfig $${LANG_ITALIAN} "Cancella i file di configurazione."
-
-  LangString ^SyncplayLanguage $${LANG_SPANISH} "es"
-  LangString ^Associate $${LANG_SPANISH} "Asociar Syncplay con archivos multimedia."
-  LangString ^Shortcut $${LANG_SPANISH} "Crear accesos directos en las siguientes ubicaciones:"
-  LangString ^StartMenu $${LANG_SPANISH} "Menú de inicio"
-  LangString ^Desktop $${LANG_SPANISH} "Escritorio"
-  LangString ^QuickLaunchBar $${LANG_SPANISH} "Barra de acceso rápido"
-  LangString ^AutomaticUpdates $${LANG_SPANISH} "Buscar actualizaciones automáticamente"
-  LangString ^UninstConfig $${LANG_SPANISH} "Borrar archivo de configuración."
-
-  LangString ^SyncplayLanguage $${LANG_PORTUGUESEBR} "pt_BR"
-  LangString ^Associate $${LANG_PORTUGUESEBR} "Associar Syncplay aos arquivos multimídia."
-  LangString ^Shortcut $${LANG_PORTUGUESEBR} "Criar atalhos nos seguintes locais:"
-  LangString ^StartMenu $${LANG_PORTUGUESEBR} "Menu Iniciar"
-  LangString ^Desktop $${LANG_PORTUGUESEBR} "Área de trabalho"
-  LangString ^QuickLaunchBar $${LANG_PORTUGUESEBR} "Barra de acesso rápido"
-  LangString ^AutomaticUpdates $${LANG_PORTUGUESEBR} "Verificar atualizações automaticamente"
-  LangString ^UninstConfig $${LANG_PORTUGUESEBR} "Deletar arquivo de configuração."
-
-  LangString ^SyncplayLanguage $${LANG_PORTUGUESE} "pt_PT"
-  LangString ^Associate $${LANG_PORTUGUESE} "Associar Syncplay aos ficheiros multimédia."
-  LangString ^Shortcut $${LANG_PORTUGUESE} "Criar atalhos nos seguintes locais:"
-  LangString ^StartMenu $${LANG_PORTUGUESE} "Menu Iniciar"
-  LangString ^Desktop $${LANG_PORTUGUESE} "Área de trabalho"
-  LangString ^QuickLaunchBar $${LANG_PORTUGUESE} "Barra de acesso rápido"
-  LangString ^AutomaticUpdates $${LANG_PORTUGUESE} "Verificar atualizações automaticamente"
-  LangString ^UninstConfig $${LANG_PORTUGUESE} "Apagar ficheiro de configuração."
-
-  LangString ^SyncplayLanguage $${LANG_TURKISH} "tr"
-  LangString ^Associate $${LANG_TURKISH} "Syncplay'i ortam dosyalarıyla ilişkilendirin."
-  LangString ^Shortcut $${LANG_TURKISH} "Aşağıdaki konumlarda kısayollar oluşturun:"
-  LangString ^StartMenu $${LANG_TURKISH} "Başlangıç menüsü"
-  LangString ^Desktop $${LANG_TURKISH} "Masaüstü"
-  LangString ^QuickLaunchBar $${LANG_TURKISH} "Hızlı Başlatma Çubuğu"
-  LangString ^AutomaticUpdates $${LANG_TURKISH} "Güncellemeleri otomatik denetle"
-  LangString ^UninstConfig $${LANG_TURKISH} "Yapılandırma dosyasını silin."
-  
-  LangString ^SyncplayLanguage $${LANG_FRENCH} "fr"
-  LangString ^Associate $${LANG_FRENCH} "Associer Syncplay avec les fichiers multimedias."
-  LangString ^Shortcut $${LANG_FRENCH} "Créer Racourcis pour les chemins suivants:"
-  LangString ^StartMenu $${LANG_FRENCH} "Menu Démarrer"
-  LangString ^Desktop $${LANG_FRENCH} "Bureau"
-  LangString ^QuickLaunchBar $${LANG_FRENCH} "Barre de Lancement Rapide"
-  LangString ^AutomaticUpdates $${LANG_FRENCH} "Vérifier automatiquement les mises à jour"
-  LangString ^UninstConfig $${LANG_FRENCH} "Supprimer le fichier de configuration."
-  
-  LangString ^SyncplayLanguage $${LANG_SIMPCHINESE} "zh_CN"
-  LangString ^Associate $${LANG_SIMPCHINESE} "将Syncplay与多媒体文件关联。"
-  LangString ^Shortcut $${LANG_SIMPCHINESE} "在以下位置创建快捷方式:"
-  LangString ^StartMenu $${LANG_SIMPCHINESE} "开始菜单"
-  LangString ^Desktop $${LANG_SIMPCHINESE} "桌面"
-  LangString ^QuickLaunchBar $${LANG_SIMPCHINESE} "快速启动栏"
-  LangString ^AutomaticUpdates $${LANG_SIMPCHINESE} "自动检查更新"
-  LangString ^UninstConfig $${LANG_SIMPCHINESE} "删除配置文件"
-
+  """ + versionKeysString + languageString + r"""
   ; Remove text to save space
   LangString ^ClickInstall $${LANG_GERMAN} " "
 

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -2,8 +2,11 @@
 
 """Deutsch dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 de = {
     "LANGUAGE": "Deutsch",  # (German)
+    "LANGUAGE-TAG": "de",
 
     # Client notifications
     "config-cleared-notification": "Einstellungen gelöscht. Änderungen werden gespeichert, wenn du eine gültige Konfiguration speicherst.",
@@ -525,4 +528,15 @@ de = {
 
     "playlist-empty-error": "Playlist is currently empty.", # TO DO: Translate
     "playlist-invalid-index-error": "Invalid playlist index", # TO DO: Translate
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "German.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Syncplay als Standardprogramm für Multimedia-Dateien verwenden.",
+    "installer-shortcut": "Erstelle Verknüpfungen an folgenden Orten:",
+    "installer-start-menu": "Startmenü",
+    "installer-desktop": "Desktop",
+    "installer-quick-launch-bar": "Schnellstartleiste",
+    "installer-automatic-updates": "Automatisch nach Updates suchen;",
+    "installer-uninstall-configuration": "Konfigurationsdatei löschen.",
 }

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -2,8 +2,11 @@
 
 """English dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 en = {
     "LANGUAGE": "English",
+    "LANGUAGE-TAG": "en",
 
     # Client notifications
     "config-cleared-notification": "Settings cleared. Changes will be saved when you store a valid configuration.",
@@ -526,4 +529,15 @@ en = {
 
     "playlist-empty-error": "Playlist is currently empty.",
     "playlist-invalid-index-error": "Invalid playlist index",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "English.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Associate Syncplay with multimedia files.",
+    "installer-shortcut": "Create Shortcuts in following locations:",
+    "installer-start-menu": "Start Menu",
+    "installer-desktop": "Desktop",
+    "installer-quick-launch-bar": "Quick Launch Bar",
+    "installer-automatic-updates": "Check for updates automatically",
+    "installer-uninstall-configuration": "Delete configuration file.",
 }

--- a/syncplay/messages_eo.py
+++ b/syncplay/messages_eo.py
@@ -2,10 +2,13 @@
 
 """Esperanto dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 # Komentoj kun tradukistaj notoj komenciĝas per «FARU:».
 
 eo = {
     "LANGUAGE": "Esperanto",
+    "LANGUAGE-TAG": "eo",
 
     # Client notifications
     "config-cleared-notification": "Agordoj vakiĝis. Ŝanĝoj konserviĝos kiam vi enmemorigos validan agordaron.",
@@ -529,4 +532,15 @@ eo = {
 
     "playlist-empty-error": "Ludlisto nun estas malplena.",
     "playlist-invalid-index-error": "Nevalida indico de ludlisto",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Esperanto.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Asocii vidaŭdaĵajn dosierojn kun Syncplay.",
+    "installer-shortcut": "Krei mallongigojn en la jenaj lokoj:",
+    "installer-start-menu": "Start-menuo",
+    "installer-desktop": "Labortablo",
+    "installer-quick-launch-bar": "Tujbreto",
+    "installer-automatic-updates": "Kontroli ĝisdatigojn memage",
+    "installer-uninstall-configuration": "Forigi dosieron kun agordaro.",
 }

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -2,8 +2,11 @@
 
 """Spanish dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 es = {
     "LANGUAGE": "Español",
+    "LANGUAGE-TAG": "es",
 
     # Client notifications
     "config-cleared-notification": "Ajustes limpiados. Los cambios serán guardados cuando almacenes una configuración válida.",
@@ -525,4 +528,15 @@ es = {
 
     "playlist-empty-error": "Playlist is currently empty.", # TO DO: Translate
     "playlist-invalid-index-error": "Invalid playlist index", # TO DO: Translate
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Spanish.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Asociar Syncplay con archivos multimedia.",
+    "installer-shortcut": "Crear accesos directos en las siguientes ubicaciones:",
+    "installer-start-menu": "Menú de inicio",
+    "installer-desktop": "Escritorio",
+    "installer-quick-launch-bar": "Barra de acceso rápido",
+    "installer-automatic-updates": "Buscar actualizaciones automáticamente",
+    "installer-uninstall-configuration": "Borrar archivo de configuración.",
 }

--- a/syncplay/messages_fr.py
+++ b/syncplay/messages_fr.py
@@ -2,8 +2,11 @@
 
 """French dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 fr = {
     "LANGUAGE": "Français",
+    "LANGUAGE-TAG": "fr",
 
     # Client notifications
     "config-cleared-notification": "Paramètres effacés. Les modifications seront enregistrées lorsque vous enregistrez une configuration valide.",
@@ -526,4 +529,15 @@ fr = {
 
     "playlist-empty-error": "La liste de lecture est actuellement vide.",
     "playlist-invalid-index-error": "Index de liste de lecture non valide",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "French.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Associer Syncplay avec les fichiers multimedias.",
+    "installer-shortcut": "Créer Racourcis pour les chemins suivants:",
+    "installer-start-menu": "Menu Démarrer",
+    "installer-desktop": "Bureau",
+    "installer-quick-launch-bar": "Barre de Lancement Rapide",
+    "installer-automatic-updates": "Vérifier automatiquement les mises à jour",
+    "installer-uninstall-configuration": "Supprimer le fichier de configuration.",
 }

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -2,8 +2,11 @@
 
 """Italian dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 it = {
     "LANGUAGE": "Italiano",
+    "LANGUAGE-TAG": "it",
 
     # Client notifications
     "config-cleared-notification": "Impostazioni iniziali ripristinate. I cambiamenti saranno memorizzati quando salverai una configurazione valida.",
@@ -525,4 +528,15 @@ it = {
 
     "playlist-empty-error": "Playlist is currently empty.",  # TO DO: Translate
     "playlist-invalid-index-error": "Invalid playlist index", # TO DO: Translate
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Italian.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Associa Syncplay con i file multimediali.",
+    "installer-shortcut": "Crea i collegamenti nei percorsi seguenti:",
+    "installer-start-menu": "Menu Start",
+    "installer-desktop": "Desktop",
+    "installer-quick-launch-bar": "Barra di avvio rapido",
+    "installer-automatic-updates": "Controllo automatico degli aggiornamenti",
+    "installer-uninstall-configuration": "Cancella i file di configurazione.",
 }

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -2,8 +2,11 @@
 
 """Brazilian Portuguese dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 pt_BR = {
     "LANGUAGE": "Português do Brasil",
+    "LANGUAGE-TAG": "pt_BR",
 
     # Client notifications
     "config-cleared-notification": "Configurações removidas. Mudanças serão salvas quando você armazenar uma configuração válida.",
@@ -526,4 +529,15 @@ pt_BR = {
 
     "playlist-empty-error": "A playlist está atualemnte vazia.",
     "playlist-invalid-index-error": "Índice inválido na playlist.",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "PortugueseBR.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Associar Syncplay aos arquivos multimídia.",
+    "installer-shortcut": "Criar atalhos nos seguintes locais:",
+    "installer-start-menu": "Menu Iniciar",
+    "installer-desktop": "Área de trabalho",
+    "installer-quick-launch-bar": "Barra de acesso rápido",
+    "installer-automatic-updates": "Verificar atualizações automaticamente",
+    "installer-uninstall-configuration": "Deletar arquivo de configuração.",
 }

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -2,8 +2,11 @@
 
 """Portugal Portuguese dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 pt_PT = {
     "LANGUAGE": "Português de Portugal",
+    "LANGUAGE-TAG": "pt_PT",
 
     # Client notifications
     "config-cleared-notification": "Configurações removidas. As mudanças serão salvas quando você armazenar uma configuração válida.",
@@ -525,4 +528,15 @@ pt_PT = {
 
     "playlist-empty-error": "Playlist is currently empty.",  # TO DO: Translate
     "playlist-invalid-index-error": "Invalid playlist index", # TO DO: Translate
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Portuguese.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Associar Syncplay aos ficheiros multimédia.",
+    "installer-shortcut": "Criar atalhos nos seguintes locais:",
+    "installer-start-menu": "Menu Iniciar",
+    "installer-desktop": "Área de trabalho",
+    "installer-quick-launch-bar": "Barra de acesso rápido",
+    "installer-automatic-updates": "Verificar atualizações automaticamente",
+    "installer-uninstall-configuration": "Apagar ficheiro de configuração.",
 }

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -2,8 +2,11 @@
 
 """Russian dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 ru = {
     "LANGUAGE": "Русский",  # (Russian)
+    "LANGUAGE-TAG": "ru",
 
     # Client notifications
     "config-cleared-notification": "Настройки сброшены. Изменения вступят в силу при сохранении корректной конфигурации.",
@@ -521,4 +524,15 @@ ru = {
 
     "playlist-empty-error": "Список воспроизведения пуст.",
     "playlist-invalid-index-error": "Неверный индекс в списке воспроизведения",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Russian.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Ассоциировать Syncplay с видеофайлами",
+    "installer-shortcut": "Создать ярлыки:",
+    "installer-start-menu": "в меню Пуск",
+    "installer-desktop": "на рабочем столе",
+    "installer-quick-launch-bar": "в меню быстрого запуска",
+    "installer-automatic-updates": "Проверять обновления автоматически", # TODO: Confirm Russian translation ("Check for updates automatically")
+    "installer-uninstall-configuration": "Удалить файл настроек.",
 }

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -2,8 +2,11 @@
 
 """Turkish dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 tr = {
     "LANGUAGE": "Türkçe", # Turkish
+    "LANGUAGE-TAG": "tr",
 
     # Client notifications
     "config-cleared-notification": "Ayarlar temizlendi. Geçerli bir konfigürasyon kaydettiğinizde değişiklikler kaydedilecektir.",
@@ -526,4 +529,15 @@ tr = {
 
     "playlist-empty-error": "Oynatma listesi şu anda boş.",
     "playlist-invalid-index-error": "Geçersiz oynatma listesi dizini",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "Turkish.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "Syncplay'i ortam dosyalarıyla ilişkilendirin.",
+    "installer-shortcut": "Aşağıdaki konumlarda kısayollar oluşturun:",
+    "installer-start-menu": "Başlangıç menüsü",
+    "installer-desktop": "Masaüstü",
+    "installer-quick-launch-bar": "Hızlı Başlatma Çubuğu",
+    "installer-automatic-updates": "Güncellemeleri otomatik denetle",
+    "installer-uninstall-configuration": "Yapılandırma dosyasını silin.",
 }

--- a/syncplay/messages_zh_CN.py
+++ b/syncplay/messages_zh_CN.py
@@ -2,8 +2,11 @@
 
 """Simplified Chinese dictionary"""
 
+# Filename, dictionary name and LANGUAGE-TAG value based on ISO country code. Language tag listed at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN
+
 zh_CN = {
     "LANGUAGE": "简体中文",
+    "LANGUAGE-TAG": "zh_CN",
 
     # Client notifications
     "config-cleared-notification": "设置已清除。 当你存储一个有效的配置时，更改将被保存。",
@@ -526,4 +529,15 @@ zh_CN = {
 
     "playlist-empty-error": "播放列表目前是空的。",
     "playlist-invalid-index-error": "无效的播放列表索引",
+
+    # Strings for Windows NSIS installer
+
+    "installer-language-file": "SimpChinese.nlf", # Relevant .nlf file at https://github.com/kichik/nsis/tree/master/Contrib/Language%20files
+    "installer-associate": "将Syncplay与多媒体文件关联。",
+    "installer-shortcut": "在以下位置创建快捷方式:",
+    "installer-start-menu": "开始菜单",
+    "installer-desktop": "桌面",
+    "installer-quick-launch-bar": "快速启动栏",
+    "installer-automatic-updates": "自动检查更新",
+    "installer-uninstall-configuration": "删除配置文件",
 }


### PR DESCRIPTION
This refactor moves the message files from buildPy2Exe.py to the respective messages_*.py files for the languages.

Benefits:
* Easier to maintain those languages as all the text is in the same place.
* Simplifies the process of adding new languages to Syncplay (and of creating any guides to explain how to do this).
* Makes it easier for any future move to services such as Weblate as per #550