### PR TITLE
Log --debug as UTF-8 to fix charmap mapping

### DIFF
--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -195,13 +195,13 @@ def blackholeStdoutForFrozenWindow():
             _file = None
             _error = None
 
-            def write(self, text, fname='.syncplay.log', encoding='utf-8'):
+            def write(self, text, fname='.syncplay.log'):
                 if self._file is None and self._error is None:
                     if os.name != 'nt':
                         path = os.path.join(os.getenv('HOME', '.'), fname)
                     else:
                         path = os.path.join(os.getenv('APPDATA', '.'), fname)
-                    self._file = open(path, 'a')
+                    self._file = open(path, 'a', encoding='utf-8')
                     # TODO: Handle errors.
                 if self._file is not None:
                     self._file.write(text)

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -195,7 +195,7 @@ def blackholeStdoutForFrozenWindow():
             _file = None
             _error = None
 
-            def write(self, text, fname='.syncplay.log'):
+            def write(self, text, fname='.syncplay.log', encoding='utf-8'):
                 if self._file is None and self._error is None:
                     if os.name != 'nt':
                         path = os.path.join(os.getenv('HOME', '.'), fname)


### PR DESCRIPTION
This should fix errors such as:
>  File "syncplay\players\mpv.pyc", line 743, in actuallySendLine
>     File "syncplay\client.pyc", line 1626, in showDebugMessage
> builtins.UnicodeEncodeError: 'charmap' codec can't encode character '\u3009' in position 684: character maps to <undefined>

When using Syncplay with mpv and--debug mode on Windows.