### PR TITLE
Add wildcard matching of trusted subdomains (#587)

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -569,8 +569,15 @@ class SyncplayClient(object):
         if self._config['trustedDomains']:
             for entry in self._config['trustedDomains']:
                 trustedDomain, _, path = entry.partition('/')
-                if o.hostname not in (trustedDomain, "www." + trustedDomain):
-                    # domain does not match
+                foundMatch = False
+                if o.hostname in (trustedDomain, "www." + trustedDomain):
+                    foundMatch = True
+                elif "*" in trustedDomain:
+                    wildcardRegex = "^("+re.escape(trustedDomain).replace("\\*","([^.]+)")+")$"
+                    wildcardMatch = bool(re.fullmatch(wildcardRegex, o.hostname, re.IGNORECASE))
+                    if wildcardMatch:
+                        foundMatch = True
+                if not foundMatch:
                     continue
                 if path and not o.path.startswith('/' + path):
                     # trusted domain has a path component and it does not match


### PR DESCRIPTION
This change should mean that if someone specifies *.example.com as a trusted domain then abc.example.com will be recognised as a trusted domain. See #587 and #437.