### PR TITLE
Restore server-side playlist on reconnect (#567)

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1929,7 +1929,13 @@ class SyncplayPlaylist():
             self._ui.showMessage("Playlist saved as {}".format(path)) # TODO: Move to messages_en
 
 
+    def playlistNeedsRestoring(self, files, username):
+        return self._client.sharedPlaylistIsEnabled() and self._playlist != None and files == [] and username == None and not self._playlistBufferIsFromOldRoom(self._client.userlist.currentUser.room)
+
     def changePlaylist(self, files, username=None, resetIndex=False):
+        if self.playlistNeedsRestoring(files, username):
+            files = self._playlist.copy()
+            self._playlist = []
         self.queuedIndexFilename = None
         if self._playlist == files:
             if self._playlistIndex != 0 and resetIndex:

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1932,10 +1932,16 @@ class SyncplayPlaylist():
     def playlistNeedsRestoring(self, files, username):
         return self._client.sharedPlaylistIsEnabled() and self._playlist != None and files == [] and username == None and not self._playlistBufferIsFromOldRoom(self._client.userlist.currentUser.room)
 
+    def playlistNeedsRestoring(self, files, username):
+        return self._client.sharedPlaylistIsEnabled() and len(self._playlist) > 0 and not files and username == None and (self._previousPlaylistRoom == None or self._previousPlaylistRoom == self._client.userlist.currentUser.room)
+
     def changePlaylist(self, files, username=None, resetIndex=False):
         if self.playlistNeedsRestoring(files, username):
+            self._ui.showDebugMessage("Restoring playlist on reconnect...")
             files = self._playlist.copy()
-            self._playlist = []
+            self._client._protocol.setPlaylist(files)
+            self._client._protocol.setPlaylistIndex(self._playlistIndex)
+            return
         self.queuedIndexFilename = None
         if self._playlist == files:
             if self._playlistIndex != 0 and resetIndex:


### PR DESCRIPTION
Address the issue raised in #567 where, if you were the only one in the room when you were disconnected, the shared playlist is empty for everyone else after reconnection until something is added/removed from the playlist.