### PR TITLE
Define desktop filename for Wayland compliance (fixes icon)

### DIFF
--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -521,6 +521,7 @@ class ConfigurationGetter(object):
                     raise ImportError
                 if QCoreApplication.instance() is None:
                     self.app = QtWidgets.QApplication(sys.argv)
+                    self.app.setDesktopFileName("syncplay")
                     if isWindows():
                         try:
                             from syncplay.vendor import darkdetect


### PR DESCRIPTION
Hi,

I've been using Wayland lately and I've noticed that the SyncPlay icon doesn't appear in Wayland:

![syncplay1](https://github.com/Syncplay/syncplay/assets/1988512/af03d19b-07ec-4fc2-9f26-bda0713aa13c)

According to Wayland guidelines, `setWindowIcon()` no longer works on Wayland and the new way of doing is is to reference the name of the .desktop file through the `QGuiApplication::setDesktopFileName()` function:

https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon

I added the required line in ConfigurationGetter.py since that's where the `QApplication` gets created, please tell me if you'd like it elsewhere. This change fixes the icon in Wayland:

![syncplay2](https://github.com/Syncplay/syncplay/assets/1988512/594ea5f0-6f31-455c-86ab-96c918f50e0b)

I used "syncplay" since that's how the .desktop file is called, but the guidelines suggest the desktop file should named in a reverse DNS style, but that's up to you.

Cheers.