### PR TITLE
Build Windows client console exe (#450)

### DIFF
--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -673,9 +673,7 @@ info = dict(
         "icon_resources": [(1, "syncplay\\resources\\icon.ico")],
         'dest_base': "Syncplay"},
     ],
-    console=['syncplayServer.py'],
-    # *** If you wish to make the Syncplay client use console mode (for --no-gui to work) then comment out the above two lines and uncomment the following line:
-    # console=['syncplayServer.py', {"script":"syncplayClient.py", "icon_resources":[(1, "resources\\icon.ico")], 'dest_base': "Syncplay"}],
+    console=['syncplayServer.py', {"script":"syncplayClient.py", "icon_resources":[(1, "syncplay\\resources\\icon.ico")], 'dest_base': "SyncplayConsole"}],
 
     options={
         'py2exe': {

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -412,6 +412,8 @@ class ConfigurationGetter(object):
             if error:
                 print("{}!".format(error))
             print(getMessage("missing-arguments-error"))
+            if utils.isWindowsConsole():
+                input(getMessage("enter-to-exit-prompt"))
             sys.exit()
         else:
             from syncplay.ui.GuiConfiguration import GuiConfiguration

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -408,7 +408,7 @@ class ConfigurationGetter(object):
                 sys.exit()
 
     def _promptForMissingArguments(self, error=None):
-        if self._config['noGui']:
+        if self._config['noGui'] or utils.isWindowsConsole():
             if error:
                 print("{}!".format(error))
             print(getMessage("missing-arguments-error"))
@@ -550,7 +550,7 @@ class ConfigurationGetter(object):
         # Arguments not validated yet - booleans are still text values
         if self._config['language']:
             setLanguage(self._config['language'])
-        if (self._config['forceGuiPrompt'] == "True" or not self._config['file']) and not self._config['noGui']:
+        if (self._config['forceGuiPrompt'] == "True" or not self._config['file']) and not self._config['noGui'] and not utils.isWindowsConsole():
             self._forceGuiPrompt()
         self._checkConfig()
         self._saveConfig(iniPath)

--- a/syncplay/ui/__init__.py
+++ b/syncplay/ui/__init__.py
@@ -6,7 +6,7 @@ if "QT_PREFERRED_BINDING" not in os.environ:
         ["PySide6", "PySide2", "PySide", "PyQt5", "PyQt4"]
     )
 
-if not isWindowsConsole:
+if not isWindowsConsole():
     try:
         from syncplay.ui.gui import MainWindow as GraphicalUI
     except ImportError:
@@ -15,7 +15,7 @@ from syncplay.ui.consoleUI import ConsoleUI
 
 
 def getUi(graphical=True, passedBar=None):
-    if graphical and not isWindowsConsole:
+    if graphical and not isWindowsConsole():
         ui = GraphicalUI(passedBar=passedBar)
     else:
         ui = ConsoleUI()

--- a/syncplay/ui/__init__.py
+++ b/syncplay/ui/__init__.py
@@ -1,19 +1,21 @@
 import os
+from syncplay.utils import isWindowsConsole
 
 if "QT_PREFERRED_BINDING" not in os.environ:
     os.environ["QT_PREFERRED_BINDING"] = os.pathsep.join(
         ["PySide6", "PySide2", "PySide", "PyQt5", "PyQt4"]
     )
 
-try:
-    from syncplay.ui.gui import MainWindow as GraphicalUI
-except ImportError:
-    pass
+if not isWindowsConsole:
+    try:
+        from syncplay.ui.gui import MainWindow as GraphicalUI
+    except ImportError:
+        pass
 from syncplay.ui.consoleUI import ConsoleUI
 
 
 def getUi(graphical=True, passedBar=None):
-    if graphical:
+    if graphical and not isWindowsConsole:
         ui = GraphicalUI(passedBar=passedBar)
     else:
         ui = ConsoleUI()

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -37,6 +37,8 @@ def isMacOS():
 def isBSD():
     return constants.OS_BSD in sys.platform or sys.platform.startswith(constants.OS_DRAGONFLY)
 
+def isWindowsConsole():
+    return os.path.basename(sys.executable) == "SyncplayConsole.exe"
 
 def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
     """Retry calling the decorated function using an exponential backoff.
@@ -223,6 +225,28 @@ def blackholeStdoutForFrozenWindow():
                 pass
 
         sys.stdout = Blackhole()
+        del Blackhole
+
+    elif getattr(sys, 'frozen', '') == "console_exe":
+        class Blackhole(object):
+            softspace = 0
+
+            def write(self, text):
+                pass
+
+            def flush(self):
+                pass
+
+        class Stderr(object):
+            softspace = 0
+            _file = None
+            _error = None
+
+            def flush(self):
+                if self._file is not None:
+                    self._file.flush()
+
+        sys.stderr = Blackhole()
         del Blackhole
 
 

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -227,7 +227,7 @@ def blackholeStdoutForFrozenWindow():
         sys.stdout = Blackhole()
         del Blackhole
 
-    elif getattr(sys, 'frozen', '') == "console_exe":
+    elif isWindowsConsole():
         class Blackhole(object):
             softspace = 0
 


### PR DESCRIPTION
Bundle console version of Syncplay client (`syncplayConsole.exe`) alongside the graphical-based version of the client (`Syncplay.exe`) in the Windows releases of Syncplay.

**Use cases:**
1. Workaround for have problems running the graphical version of Syncplay due to Windows library issues (e.g. #630)
2. Allows user to use a .vbs script to quietly launch Syncplay in the background while having only the mpv window visible (#450).

Feature requested by @siferati in #450.