### PR TITLE
Update to python 3.12

### DIFF
--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -5,7 +5,7 @@ import codecs
 import re
 import os
 import sys
-from configparser import SafeConfigParser, DEFAULTSECT
+from configparser import ConfigParser, DEFAULTSECT
 
 from syncplay import constants, utils, version, milestone
 from syncplay.messages import getMessage, setLanguage, isValidLanguage
@@ -389,7 +389,7 @@ class ConfigurationGetter(object):
                 open(iniPath, 'w').close()
             else:
                 return
-        parser.readfp(codecs.open(iniPath, "r", "utf_8_sig"))
+        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
         for section, options in list(self._iniStructure.items()):
             if parser.has_section(section):
                 for option in options:
@@ -432,7 +432,7 @@ class ConfigurationGetter(object):
         if self._config['noStore']:
             return
         parser = SafeConfigParserUnicode(strict=False)
-        parser.readfp(codecs.open(iniPath, "r", "utf_8_sig"))
+        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
         for section, options in list(self._iniStructure.items()):
             if not parser.has_section(section):
                 parser.add_section(section)
@@ -593,7 +593,7 @@ class ConfigurationGetter(object):
         self._config = backup
 
 
-class SafeConfigParserUnicode(SafeConfigParser):
+class SafeConfigParserUnicode(ConfigParser):
     def write(self, fp):
         """Write an .ini-format representation of the configuration state."""
         if self._defaults:

--- a/syncplay/ui/ConfigurationGetter.py
+++ b/syncplay/ui/ConfigurationGetter.py
@@ -389,7 +389,7 @@ class ConfigurationGetter(object):
                 open(iniPath, 'w').close()
             else:
                 return
-        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
+        parser.read_file(codecs.open(iniPath, "r", "utf_8_sig"))
         for section, options in list(self._iniStructure.items()):
             if parser.has_section(section):
                 for option in options:
@@ -432,7 +432,7 @@ class ConfigurationGetter(object):
         if self._config['noStore']:
             return
         parser = SafeConfigParserUnicode(strict=False)
-        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
+        parser.read_file(codecs.open(iniPath, "r", "utf_8_sig"))
         for section, options in list(self._iniStructure.items()):
             if not parser.has_section(section):
                 parser.add_section(section)


### PR DESCRIPTION
`SafeConfigParser` was renamed to `ConfigParser` ([docs](https://docs.python.org/3.12/whatsnew/3.12.html?highlight=safeconfigparser#configparser))

`.readfp()` was renamed to `.read_file()` ([docs](https://docs.python.org/3.12/library/configparser.html?highlight=readfp#configparser.ConfigParser.read_file))


Otherwise trying to run the client with python 3.12 gets you this nice error
```
> python syncplayClient.py
Traceback (most recent call last):
  File "[]/syncplay/syncplayClient.py", line 14, in <module>
    from syncplay import ep_client
  File "[]/syncplay/syncplay/ep_client.py", line 3, in <module>
    from syncplay.clientManager import SyncplayClientManager
  File "[]/syncplay/clientManager.py", line 4, in <module>
    from syncplay.ui.ConfigurationGetter import ConfigurationGetter
  File "/usr/lib/python3.12/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[]/syncplay/syncplay/ui/ConfigurationGetter.py", line 8, in <module>
    from configparser import SafeConfigParser, DEFAULTSECT
ImportError: cannot import name 'SafeConfigParser' from 'configparser' (/usr/lib/python3.12/configparser.py). Did you mean: 'RawConfigParser'?
```