### PR TITLE
Use PySide6 for non-windows + python >= 3.12

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,3 +1,3 @@
-pyside2>=5.11.0; sys_platform != 'darwin'
-pyside6; sys_platform == 'darwin'
+pyside2>=5.11.0; sys_platform != 'darwin' and (sys_platform == 'win32' or python_version < '3.12')
+pyside6; sys_platform == 'darwin' or (sys_platform != 'win32' and python_version >= '3.12')
 requests>=2.20.0; sys_platform == 'darwin'


### PR DESCRIPTION
PySide2 is dead and won't support Python 3.12 or newer.