### PR TITLE
Readiness override

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1332,10 +1332,10 @@ class SyncplayUserlist(object):
         self._client = client
         self._roomUsersChanged = True
 
-    def isReadinessSupported(self):
+    def isReadinessSupported(self, requiresOtherUsers=True):
         if not utils.meetsMinVersion(self._client.serverVersion, constants.USER_READY_MIN_VERSION):
             return False
-        elif self.onlyUserInRoomWhoSupportsReadiness():
+        elif self.onlyUserInRoomWhoSupportsReadiness() and requiresOtherUsers:
             return False
         else:
             return self._client.serverFeatures["readiness"]

--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -657,9 +657,9 @@ class SyncplayClient(object):
             "maxChatMessageLength": constants.FALLBACK_MAX_CHAT_MESSAGE_LENGTH,
             "maxUsernameLength": constants.FALLBACK_MAX_USERNAME_LENGTH,
             "maxRoomNameLength": constants.FALLBACK_MAX_ROOM_NAME_LENGTH,
-            "maxFilenameLength": constants.FALLBACK_MAX_FILENAME_LENGTH
+            "maxFilenameLength": constants.FALLBACK_MAX_FILENAME_LENGTH,
+            "setOthersReadiness": utils.meetsMinVersion(self.serverVersion, constants.SET_OTHERS_READINESS_MIN_VERSION)
         }
-
         if featureList:
             self.serverFeatures.update(featureList)
         if not utils.meetsMinVersion(self.serverVersion, constants.SHARED_PLAYLIST_MIN_VERSION):
@@ -730,6 +730,7 @@ class SyncplayClient(object):
         features["readiness"] = True
         features["managedRooms"] = True
         features["persistentRooms"] = True
+        features["setOthersReadiness"] = True
 
         return features
 
@@ -932,6 +933,10 @@ class SyncplayClient(object):
             message = utils.truncateText(message, constants.MAX_CHAT_MESSAGE_LENGTH)
             self._protocol.sendChatMessage(message)
 
+    @requireServerFeature("setOthersReadiness")
+    def setOthersReadiness(self, username, newReadyStatus):
+        self._protocol.setReady(newReadyStatus, True, username)
+
     def sendFeaturesUpdate(self, features):
         self._protocol.sendFeaturesUpdate(features)
 
@@ -1032,7 +1037,7 @@ class SyncplayClient(object):
         if newState != oldState:
             self.toggleReady(manuallyInitiated)
 
-    def setReady(self, username, isReady, manuallyInitiated=True):
+    def setReady(self, username, isReady, manuallyInitiated=True, setBy=None):
         oldReadyState = self.userlist.isReady(username)
         if oldReadyState is None:
             oldReadyState = False
@@ -1040,6 +1045,11 @@ class SyncplayClient(object):
         self.ui.userListChange()
         if oldReadyState != isReady:
             self._warnings.checkReadyStates()
+        if setBy:
+            if isReady:
+                self.ui.showMessage(getMessage("other-set-as-ready-notification").format(username, setBy))
+            else:
+                self.ui.showMessage(getMessage("other-set-as-not-ready-notification").format(username, setBy))
 
     @requireServerFeature("managedRooms")
     def setUserFeatures(self, username, features):

--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -131,6 +131,8 @@ COMMANDS_PLAYLIST = ['playlist', 'ql', 'pl']
 COMMANDS_SELECT = ['select', 'qs']
 COMMANDS_DELETE = ['delete', 'd', 'qd']
 COMMANDS_NEXT = ["next", "qn"]
+COMMANDS_SETREADY = ['setready', 'sr']
+COMMANDS_SETNOTREADY = ['setready', 'snr']
 MPC_MIN_VER = "1.6.4"
 MPC_BE_MIN_VER = "1.5.2.3123"
 VLC_MIN_VERSION = "2.2.1"
@@ -142,6 +144,7 @@ USER_READY_MIN_VERSION = "1.3.0"
 SHARED_PLAYLIST_MIN_VERSION = "1.4.0"
 CHAT_MIN_VERSION = "1.5.0"
 FEATURE_LIST_MIN_VERSION = "1.5.0"
+SET_OTHERS_READINESS_MIN_VERSION = "1.7.2"
 
 IINA_PATHS = ['/Applications/IINA.app/Contents/MacOS/IINA']
 MPC_PATHS = [

--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -62,6 +62,9 @@ de = {
     "authenticated-as-controller-notification": "{} authentifizierte sich als Raumleiter",
     "created-controlled-room-notification": "Gesteuerten Raum „{}“ mit Passwort „{}“ erstellt. Bitte diese Informationen für die Zukunft aufheben! \n\nIn managed rooms everyone is kept in sync with the room operator(s) who are the only ones who can pause, unpause, seek, and change the playlist.\n\nYou should ask regular viewers to join the room '{}' but the room operators can join the room '{}' to automatically authenticate themselves.", # RoomName, operatorPassword, roomName, roomName:operatorPassword # TODO: Translate
 
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "Deine Datei scheint sich von {}s zu unterscheiden",  # User
     "file-differences-notification": "Deine Datei unterscheidet sich auf folgende Art: {}",
     "room-file-differences": "Unterschiedlich in: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ de = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature",
     "commandlist-notification/help": "\th - Diese Hilfe",
     "commandlist-notification/toggle": "\tt - Bereitschaftsanzeige umschalten",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready", # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready", # TODO: Translate
     "commandlist-notification/create": "\tc [name] - erstelle zentral gesteuerten Raum mit dem aktuellen Raumnamen",
     "commandlist-notification/auth": "\ta [password] - authentifiziere als Raumleiter mit Passwort",
     "commandlist-notification/chat": "\tch [message] - Chatnachricht an einem Raum senden",
@@ -158,6 +163,7 @@ de = {
     "feature-chat": "Chat",  # used for not-supported-by-server-error
     "feature-readiness": "Bereitschaftsstatus",  # used for not-supported-by-server-error
     "feature-managedRooms": "Zentral gesteuerte Räume",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "Diese Funktion wird vom Server nicht unterstützt. Es wird ein Server mit Syncplay Version {}+ benötigt, aktuell verwendet wird jedoch Version {}.",  # minVersion, serverVersion
     "shared-playlists-not-supported-by-server-error": "Die Geteilte-Playlists-Funktion wird von diesem Server eventuell nicht unterstützt. Um ein korrektes Funktionieren sicherzustellen wird ein Server mit Syncplay Version {}+ benötigt, aktuell verwendet wird jedoch Version {}.",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ de = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Du nutzt Syncplay Version {}, aber es gibt eine neuere Version auf https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate - NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Willkommen zum Syncplay-Server, v. {0}",  # version
@@ -536,6 +544,9 @@ de = {
     "addotherusersstreamstoplaylist-menu-label": "{}s Stream zur Playlist hinzufügen",  # [Username]
     "openusersstream-menu-label": "{}s Stream öffnen",  # [username]'s
     "openusersfile-menu-label": "{}s Datei öffnen",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Zieh eine Datei hierher, um sie zur geteilten Playlist hinzuzufügen.",
     "sharedplaylistenabled-tooltip": "Raumleiter können Dateien zu einer geteilten Playlist hinzufügen und es so erleichtern, gemeinsam das Gleiche zu gucken. Konfiguriere Medienverzeichnisse unter „Diverse“",

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -62,6 +62,9 @@ en = {
     "authenticated-as-controller-notification": "{} authenticated as a room operator",
     "created-controlled-room-notification": "Created managed room '{}' with password '{}'. Please save this information for future reference!\n\nIn managed rooms everyone is kept in sync with the room operator(s) who are the only ones who can pause, unpause, seek, and change the playlist.\n\nYou should ask regular viewers to join the room '{}' but the room operators can join the room '{}' to automatically authenticate themselves.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready
+
     "file-different-notification": "File you are playing appears to be different from {}'s",  # User
     "file-differences-notification": "Your file differs in the following way(s): {}",  # Differences
     "room-file-differences": "File differences: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ en = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature",
     "commandlist-notification/help": "\th - this help",
     "commandlist-notification/toggle": "\tt - toggles whether you are ready to watch or not",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",
     "commandlist-notification/create": "\tc [name] - create managed room using name of current room",
     "commandlist-notification/auth": "\ta [password] - authenticate as room operator with operator password",
     "commandlist-notification/chat": "\tch [message] - send a chat message in a room",
@@ -158,6 +163,7 @@ en = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "readiness",  # used for not-supported-by-server-error
     "feature-managedRooms": "managed rooms",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error
 
     "not-supported-by-server-error": "The {} feature is not supported by this server..",  # feature
     "shared-playlists-not-supported-by-server-error": "The shared playlists feature may not be supported by the server. To ensure that it works correctly requires a server running Syncplay  {}+, but the server is running Syncplay {}.",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ en = {
     # Server messages to client
     "new-syncplay-available-motd-message": "You are using Syncplay {} but a newer version is available from https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.", # User
+    "not-ready-chat-message": "I have set {} as not ready.", # User
 
     # Server notifications
     "welcome-server-notification": "Welcome to Syncplay server, ver. {0}",  # version
@@ -537,6 +545,9 @@ en = {
     "addotherusersstreamstoplaylist-menu-label": "Add {}' stream to playlist",  # [Username]
     "openusersstream-menu-label": "Open {}'s stream",  # [username]'s
     "openusersfile-menu-label": "Open {}'s file",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready", # [Username]
+    "setasnotready-menu-label": "Set {} as not ready", # [Username]
 
     "playlist-instruction-item-message": "Drag file here to add it to the shared playlist.",
     "sharedplaylistenabled-tooltip": "Room operators can add files to a synced playlist to make it easy for everyone to watching the same thing. Configure media directories under 'Misc'.",

--- a/syncplay/messages_eo.py
+++ b/syncplay/messages_eo.py
@@ -64,6 +64,9 @@ eo = {
     "authenticated-as-controller-notification": "{} identiĝis ĉambrestro",
     "created-controlled-room-notification": "Kreis estratan ĉambron «{}» kun pasvorto «{}». Bonvolu konservi tiujn informojn osen!\n\nEn estrataj ĉambroj, ĉiu spegulas la ĉambrestrojn, kiuj estas la solaj, kiuj povas paŭzigi, malpaŭzigi, iri, kaj ŝanĝi la ludliston.\n\nVi petu ordinarajn spektantojn aliĝi la ĉambron «{}», sed ĉambrestroj povas aliĝi la ĉambron «{}» por memage aŭtentikiĝi.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "La dosiero, kiun vi ludas, ŝajnas malsama de tiu de {}",  # User
     "file-differences-notification": "Via dosiero malsamas per ĉi tiuj manieroj: {}",  # Differences
     "room-file-differences": "Malsamoj inter dosieroj: {}",  # File differences (filename, size, and/or duration)
@@ -100,6 +103,8 @@ eo = {
     "commandlist-notification/offset": "\to[+-]daŭro - fruigi lokan ludadon je la donita daŭro (en sekundoj aŭ minutoj:sekundoj), kompare al la servila pozicio – ĉi tiu kapablo ne plu estos subtenata",
     "commandlist-notification/help": "\th – tiu ĉi helpilo",
     "commandlist-notification/toggle": "\tt – ŝanĝas ĉu vi pretas spekti aŭ ne",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nomo] – krei estratan ĉambron kun nomo de la nuna ĉambro",
     "commandlist-notification/auth": "\ta [pasvorto] – aŭtentikiĝi ĉambrestro per ĉambrestra pasvorto",
     "commandlist-notification/chat": "\tch [mesaĝo] – sendi babilan mesaĝon al ĉambro",
@@ -161,6 +166,7 @@ eo = {
     "feature-chat": "babilado",  # used for not-supported-by-server-error
     "feature-readiness": "preteco",  # used for not-supported-by-server-error
     "feature-managedRooms": "estrataj ĉambroj",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "La kapablo «{}» ne estas subtenata de ĉi tiu servilo.",  # feature
     "shared-playlists-not-supported-by-server-error": "La servilo eble ne subtenas komunajn ludlistojn. Ĝusta funkciado postulas servilon kun Syncplay {}+, sed la servilo havas nur version {}.",  # minVersion, serverVersion
@@ -477,6 +483,8 @@ eo = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Vi uzas version {} de Syncplay, sed pli nova versio estas disponebla per https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "AVIZO: Ĉi tiu servilo uzas persistajn ĉámbrojn, kio signifas, ke la informoj pri ludlistoj konserviĝas por venontaj kunspektoj. Se vi volas krei ĉambron kie la informoj ne konserviĝas, finu la nomon de la ĉambro per «-temp».", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Bonvenu al servilo de Syncplay, versio {0}",  # version
@@ -540,6 +548,9 @@ eo = {
     "addotherusersstreamstoplaylist-menu-label": "Aldoni elsendon de {} al la ludlisto",  # [Username]
     "openusersstream-menu-label": "Malfermi elsendon de {}",  # [username]'s
     "openusersfile-menu-label": "Malfermi dosieron de {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Metu dosieron ĉi tien por aldoni ĝin al la komuna ludlisto.",
     "sharedplaylistenabled-tooltip": "Ĉambrestroj povas aldoni dosierojn al spegulata ludlisto, por ke ĉiuj povu facile spekti la saman filmon. Agordu vidaŭdaĵajn dosierojn sub «Diversaj».",

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -62,6 +62,9 @@ es = {
     "authenticated-as-controller-notification": "{} autentificado como operador de la sala",
     "created-controlled-room-notification": "Sala administrada '{}' creada con contraseña '{}'. Por favor guarda esta información para referencias futuras!\n\nIn managed rooms everyone is kept in sync with the room operator(s) who are the only ones who can pause, unpause, seek, and change the playlist.\n\nYou should ask regular viewers to join the room '{}' but the room operators can join the room '{}' to automatically authenticate themselves.", # RoomName, operatorPassword, roomName, roomName:operatorPassword # TODO: Translate
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "El archivo que reproduces parece ser diferente al archivo de {}",  # User
     "file-differences-notification": "Tu archivo difiere de la(s) siguiente(s) forma(s): {}",  # Differences
     "room-file-differences": "Diferencias de archivo: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ es = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - esta ayuda",
     "commandlist-notification/toggle": "\tt - activa/inactiva señal que estás listo para ver",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nombre] - crear sala administrada usando el nombre de la sala actual",
     "commandlist-notification/auth": "\ta [contraseña] - autentificar como operador de la sala con la contraseña de operador",
     "commandlist-notification/chat": "\tch [mensaje] - enviar un mensaje en la sala",
@@ -158,6 +163,7 @@ es = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "preparación",  # used for not-supported-by-server-error
     "feature-managedRooms": "salas administradas",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "La característica {} no está soportada por este servidor..",  # feature
     "shared-playlists-not-supported-by-server-error": "El servidor no admite la función de listas de reproducción compartidas. Para asegurarse de que funciona correctamente, se requiere un servidor que ejecute Syncplay {}+, pero el servidor está ejecutando Syncplay {}.",  # minVersion, serverVersion
@@ -536,6 +542,9 @@ es = {
     "addotherusersstreamstoplaylist-menu-label": "Agregar el flujo de {} a la lista de reproducción",  # [Username]
     "openusersstream-menu-label": "Abrir el flujo de {}",  # [username]'s
     "openusersfile-menu-label": "Abrir el archivo de {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Desplazar aquí el archivo para agregarlo a la lista de reproducción compartida.",
     "sharedplaylistenabled-tooltip": "Los operadores de la sala pueden agregar archivos a una lista de reproducción sincronizada, para que visualizar la misma cosa sea más sencillo para todos. Configurar directorios multimedia en 'Misc'.",

--- a/syncplay/messages_fi.py
+++ b/syncplay/messages_fi.py
@@ -62,6 +62,9 @@ fi = {
      "authenticated-as-controller-notification": "{} tunnistautui huoneen operaattoriksi",
      "created-controlled-room-notification": "Luotiin hallittu huone '{}' salasanalla '{}'. Kirjoita tämä talteen tulevaisuudessa löydettäväksi!\n\nHallinnoiduissa huoneissa kaikkien osallistujien kohdat pidetään synkronoituneena huoneen operaattori(e)n kanssa ja vain he voivat tauottaa, jatkaa tai kelata ja muuttaa soittolistaa.\n\nSinun tulisi pyytää vakiokatsojia liittymään huoneeseen '{}' huoneen operaattorit taas voivat liittyä huoneeseen '{}' tunnistautuakseen automaattisesti.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
      "file-different-notification": "Vaikutat toistavan eri tiedostoa verrattuna käyttäjään {}",  # User
      "file-differences-notification": "Tiedostosi poikkeaa seuraavasti: {}",  # Differences
      "room-file-differences": "Tiedostoerot: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ fi = {
      "commandlist-notification/offset": "\to[+-]kesto - tee aikaero palvelimeen paikallisesti keston verran - tämä ominaisuus on deprekoitu",
      "commandlist-notification/help": "\th - tämä ohje",
      "commandlist-notification/toggle": "\tt - määrittää oletko valmis aloittamaan katselun vaiko et",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
      "commandlist-notification/create": "\tc [nimi] - tee tästä huoneesta hallittu",
      "commandlist-notification/auth": "\ta [salasana] - tunnistaudu operaattoriksi salasanalla",
      "commandlist-notification/chat": "\tch [viesti] - lähetä viesti huoneeseen",
@@ -158,6 +163,7 @@ fi = {
      "feature-chat": "keskustelu",  # used for not-supported-by-server-error
      "feature-readiness": "valmius",  # used for not-supported-by-server-error
      "feature-managedRooms": "hallinnoidut huoneet",  # used for not-supported-by-server-error
+     "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
      "not-supported-by-server-error": "Tämä {} ominaisuus ei ole tämän palvelimen tukema..",  # feature
      "shared-playlists-not-supported-by-server-error": "Jaetut toistoluettelot eivät välttämättä ole palvelimen tukemia. Varmistaaksesi että kaikki toimii oikein vaaditaan palvelin jossa ajetaan Syncplaytä  {}+, mutta palvelin ajaa Syncplayn versiota {}.",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ fi = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Käytät Syncplay:tä {} mutta uudempi julkaisu on tarjolla osoitteessa https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "HUOMIO: Tämä palvelin käyttää pysyviä huoneita, joka tarkoittaa, että toistoluettelojen tieto taltioidaan toistoistuntojen välillä. Mikäli halkuat luoda huoneen jossa tietoja ei tallenneta, laita vipu -temp huoneen nimen perään.", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Tervetuloa Syncplay-palvelimelle, ver. {0}",  # version
@@ -533,6 +541,9 @@ fi = {
     "addotherusersstreamstoplaylist-menu-label": "Lisää {}'n suoratoisto toistoluetteloon",  # [Username]
     "openusersstream-menu-label": "Avaa {}'n suoratoisto",  # [username]'s
     "openusersfile-menu-label": "Avaa {}'n tiedosto",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Raahaa tiedosto tähän lisätäksesi sen jaettuun toistoluetteloon.",
     "sharedplaylistenabled-tooltip": "Huonevalvojat voivat lisätä tiedostoja yhdennettävään toistoluetteloon tehdäkseen kaikille helpoksi katsoa samaa asiaa. Määritä mediahakemistot kohteen 'Muut' alta.",

--- a/syncplay/messages_fr.py
+++ b/syncplay/messages_fr.py
@@ -62,6 +62,9 @@ fr = {
     "authenticated-as-controller-notification": "{} authentifié en tant qu'opérateur de salle",
     "created-controlled-room-notification": "Salle gérée créée «{}» avec le mot de passe «{}». Veuillez conserver ces informations pour référence future !\n\nDans les salons gérés, tout le monde est synchronisé avec le ou les opérateurs de salon qui sont les seuls à pouvoir mettre en pause, reprendre, se déplacer dans la lecture et modifier la liste de lecture.\n\nVous devez demander aux spectateurs réguliers de rejoindre le salon '{}' mais les opérateurs de salon peuvent rejoindre le salon '{}' pour s'authentifier automatiquement.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "Le fichier que vous lisez semble être différent de celui de {}",  # User
     "file-differences-notification": "Votre fichier diffère de la (des) manière(s) suivante(s): {}",  # Differences
     "room-file-differences": "Différences de fichiers: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ fr = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - cette aide",
     "commandlist-notification/toggle": "\tt - bascule si vous êtes prêt à regarder ou non",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nom] - crée une salle gérée en utilisant le nom de la salle actuelle",
     "commandlist-notification/auth": "\tun [mot de passe] - s'authentifier en tant qu'opérateur de salle avec le mot de passe opérateur",
     "commandlist-notification/chat": "\tch [message] - envoyer un message de chat dans une pièce",
@@ -158,6 +163,7 @@ fr = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "préparation",  # used for not-supported-by-server-error
     "feature-managedRooms": "salons gérés",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "La fonctionnalité {} n'est pas prise en charge par ce serveur.",  # feature
     "shared-playlists-not-supported-by-server-error": "La fonctionnalité de listes de lecture partagées peut ne pas être prise en charge par le serveur. Pour s'assurer qu'il fonctionne correctement, il faut un serveur exécutant Syncplay {}+, mais le serveur exécute Syncplay {}.",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ fr = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Vous utilisez Syncplay {} mais une version plus récente est disponible sur https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # NOTE: Do not translate the word -temp # TODO: Translate
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Bienvenue sur le serveur Syncplay, ver.",  # version
@@ -537,6 +545,9 @@ fr = {
     "addotherusersstreamstoplaylist-menu-label": "Ajouter {}' stream à la playlist",  # [Username]
     "openusersstream-menu-label": "Ouvrir le flux de {}",  # [username]'s
     "openusersfile-menu-label": "Ouvrir le fichier de {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Faites glisser le fichier ici pour l'ajouter à la liste de lecture partagée.",
     "sharedplaylistenabled-tooltip": "Les opérateurs de salle peuvent ajouter des fichiers à une liste de lecture synchronisée pour permettre à tout le monde de regarder facilement la même chose. Configurez les répertoires multimédias sous «Divers».",

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -62,6 +62,9 @@ it = {
     "authenticated-as-controller-notification": "{} autenticato come gestore della stanza",
     "created-controlled-room-notification": "Stanza gestita '{}' creata con password '{}'. Per favore salva queste informazioni per una consultazione futura!\n\nIn managed rooms everyone is kept in sync with the room operator(s) who are the only ones who can pause, unpause, seek, and change the playlist.\n\nYou should ask regular viewers to join the room '{}' but the room operators can join the room '{}' to automatically authenticate themselves.", # RoomName, operatorPassword, roomName, roomName:operatorPassword # TODO: Translate
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "Il file che stai riproducendo sembra essere diverso da quello di {}",  # User
     "file-differences-notification": "Il tuo file mostra le seguenti differenze: {}",  # Differences
     "room-file-differences": "Differenze: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ it = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - mostra questo help",
     "commandlist-notification/toggle": "\tt - attiva o disattiva la funzionalità \"pronto\"",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nome] - crea una stanza gestita usando il nome della stanza attuale",
     "commandlist-notification/auth": "\ta [password] - autentica come gestore della stanza, utilizzando la password del gestore",
     "commandlist-notification/chat": "\tch [message] - invia un messaggio nella chat della stanza",
@@ -158,6 +163,7 @@ it = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "pronto",  # used for not-supported-by-server-error
     "feature-managedRooms": "stanze gestite",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "La feature {} non è supportata da questo server..",  # feature
     "shared-playlists-not-supported-by-server-error": "Le playlist condivise potrebbero non essere supportata dal server. È necessario un server con Syncplay {}+ per assicurarsi che funzionino correttamente, tuttavia il server sta utilizzando Syncplay {}.",  # minVersion, serverVersion
@@ -473,6 +479,8 @@ it = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Stai usando Syncplay {} ma una nuova versione è disponibile presso https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate - NOTE: Do not translate the word -temp to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Benvenuto nel server Syncplay, ver. {0}",  # version
@@ -536,6 +544,9 @@ it = {
     "addotherusersstreamstoplaylist-menu-label": "Aggiungi l'indirizzo di {} alla playlist", # Username  # item owner indicator
     "openusersstream-menu-label": "Apri l'indirizzo di {}",  # [username]
     "openusersfile-menu-label": "Apri il file di {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Trascina qui i file per aggiungerli alla playlist condivisa.",
     "sharedplaylistenabled-tooltip": "Gli operatori della stanza possono aggiungere i file a una playlist sincronizzata per garantire che tutti i partecipanti stiano guardando la stessa cosa. Configura le cartelle multimediali alla voce 'Miscellanea'.",

--- a/syncplay/messages_ko.py
+++ b/syncplay/messages_ko.py
@@ -62,6 +62,9 @@ ko = {
     "authenticated-as-controller-notification": "{}님이 방 운영자로 인증되었습니다",
     "created-controlled-room-notification": "'{}' 방을 '{}' 비밀번호로 관리되게 만들었습니다. 나중에 참조할 수 있도록 이 정보를 저장하세요!\n\n관리되는 방에서는 모든 사람이 재생목록을 일시 중지, 일시 중지 해제, 검색 및 변경할 수 있는 유일한 사람인 방 운영자와 동기화 상태를 유지합니다.\n\n일반 시청자에게 '{}' 방에 참여하도록 요청해야 하지만, 방 운영자는 '{}' 방에 참여하여 자동으로 자신을 인증할 수 있습니다.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "재생 중인 파일이 {}님의 파일과 다른 것 같습니다",  # User
     "file-differences-notification": "다음과 같은 방식으로 당신의 파일이 다릅니다: {}",  # Differences
     "room-file-differences": "파일 차이점: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ ko = {
     "commandlist-notification/offset": "\to[+-]duration - 서버 탐색 위치에서 지정된 시간(초 또는 분:초)만큼 로컬 재생을 오프셋합니다 - 이 기능은 사용되지 않습니다",
     "commandlist-notification/help": "\th - 이 도움말",
     "commandlist-notification/toggle": "\tt - 시청 준비 여부를 전환합니다",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [name] - 현재 방의 이름을 사용하여 관리되는 방을 만듭니다",
     "commandlist-notification/auth": "\ta [password] - 운영자 비밀번호를 사용해 방 운영자로 인증합니다",
     "commandlist-notification/chat": "\tch [message] - 방에서 채팅 메시지를 전송합니다",
@@ -158,6 +163,7 @@ ko = {
     "feature-chat": "채팅",  # used for not-supported-by-server-error
     "feature-readiness": "준비",  # used for not-supported-by-server-error
     "feature-managedRooms": "관리되는 방",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "{} 기능은 이 서버에서 지원되지 않습니다..",  # feature
     "shared-playlists-not-supported-by-server-error": "공유 재생목록 기능은 서버에서 지원하지 않을 수 있습니다. 올바르게 작동하려면 Syncplay {}+를 실행하는 서버가 필요하지만 서버는 Syncplay {}를 실행하고 있습니다.",  # minVersion, serverVersion
@@ -473,6 +479,8 @@ ko = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Syncplay {}를 사용 중이지만 https://syncplay.pl에서 최신 버전을 사용할 수 있습니다",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Syncplay 서버에 오신 것을 환영합니다. 버전 {0}",  # version
@@ -532,6 +540,9 @@ ko = {
     "addotherusersstreamstoplaylist-menu-label": "재생목록에 {}' 스트림 추가하기",  # [Username]
     "openusersstream-menu-label": "{}의 스트림 열기",  # [username]'s
     "openusersfile-menu-label": "{}의 파일 열기",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "파일을 여기로 드래그하여 공유 재생목록에 추가하세요.",
     "sharedplaylistenabled-tooltip": "방 운영자는 동기화된 재생목록에 파일을 추가하여 모든 사람이 쉽게 같은 내용을 볼 수 있도록 할 수 있습니다. '기타'에서 미디어 디렉터리를 구성합니다.",

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -62,6 +62,8 @@ pt_BR = {
     "authenticated-as-controller-notification": "{} autenticou-se como um operador da sala",
     "created-controlled-room-notification": "Criou a sala gerenciada '{}' com a senha '{}'. Por favor, salve essa informação para futura referência!\n\nEm uma sala gerenciada, todos são mantidos em sincronia com o(s) operador(es) de sala, que é/são o(s) único(s) que pode(m) pausar, despausar, pular, e mudar a playlist.\n\nVocê deve pedir usuários comuns para se entrarem à sala '{}', mas os operadores de sala podem se entrar à sala '{}' para autenticarem-se automaticamente.", # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}", # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
 
     "file-different-notification": "O arquivo que você está tocando parece ser diferente do arquivo de {}",  # User
     "file-differences-notification": "Seus arquivos se diferem da(s) seguinte(s) forma(s): {}",  # Differences
@@ -99,6 +101,8 @@ pt_BR = {
     "commandlist-notification/offset": "\to[+-]duração - Desloca a reprodução local pelo valor de duração fornecido (em segundos ou min:seg) em relação à posição de tepmo do servidor - essa é uma função descontinuada",
     "commandlist-notification/help": "\th - esta mensagem de ajuda",
     "commandlist-notification/toggle": "\tt - alterna o seu status de prontidão para assistir",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nome] - cria uma sala gerenciada usando o nome da sala atual",
     "commandlist-notification/auth": "\ta [senha] - autentica-se como operador da sala com a senha",
     "commandlist-notification/chat": "\tch [mensagem] - envia uma mensagem no chat da sala",
@@ -159,6 +163,7 @@ pt_BR = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "prontidão",  # used for not-supported-by-server-error
     "feature-managedRooms": "salas gerenciadas",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "O recurso {} não é suportado por este servidor.",  # feature
     "shared-playlists-not-supported-by-server-error": "O recurso de playlists compartilhadas pode não ser suportado por este servidor. Para garantir que funcione corretamente, é necessário um servidor rodando Syncplay {} ou superior, mas este está rodando Syncplay {}.",  # minVersion, serverVersion
@@ -474,6 +479,8 @@ pt_BR = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Você está usando o Syncplay {}, mas uma versão mais nova está disponível em https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "AVISO: Este servidor usa salas persistentes, o que significa que as informações da playlist são salvas entre sessões de reprodução. Se você quer criar uma sala onde a informação não será salva, coloque -temp no final do nome da sala.", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Seja bem-vindo ao servidor de Syncplay, versão {0}",  # version
@@ -537,6 +544,9 @@ pt_BR = {
     "addotherusersstreamstoplaylist-menu-label": "Adicionar transmissão de {} à playlist",  # [Username]
     "openusersstream-menu-label": "Abrir transmissão de {}",  # [username]'s
     "openusersfile-menu-label": "Abrir arquivo de {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Arraste um arquivo aqui para adicioná-lo à playlist compartilhada.",
     "sharedplaylistenabled-tooltip": "Operadores da sala podem adicionar arquivos para a playlist compartilhada para tornar mais fácil para todo mundo assistir a mesma coisa. Configure os diretórios de mídia em 'Miscelânea'.",

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -62,6 +62,9 @@ pt_PT = {
     "authenticated-as-controller-notification": "{} autenticou-se como um administrador da sala",
     "created-controlled-room-notification": "Criou a sala controlada '{}' com a senha '{}'. Por favor, guarda essa informação para futura referência!\n\nIn managed rooms everyone is kept in sync with the room operator(s) who are the only ones who can pause, unpause, seek, and change the playlist.\n\nYou should ask regular viewers to join the room '{}' but the room operators can join the room '{}' to automatically authenticate themselves.", # RoomName, operatorPassword, roomName, roomName:operatorPassword # TODO: Translate
 
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "O ficheiro que você está tocando parece ser diferente do ficheiro de {}",  # User
     "file-differences-notification": "Seus ficheiros se diferem da(s) seguinte(s) forma(s): {}",  # Differences
     "room-file-differences": "Diferenças de ficheiros: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ pt_PT = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - esta mensagem de ajuda",
     "commandlist-notification/toggle": "\tt - alterna o seu status de prontidão para assistir",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [nome] - cria sala gerenciada usando o nome da sala atual",
     "commandlist-notification/auth": "\ta [senha] - autentica-se como administrador da sala com a senha",
     "commandlist-notification/chat": "\tch [mensagem] - envia uma mensagem no chat da sala",
@@ -158,6 +163,7 @@ pt_PT = {
     "feature-chat": "chat",  # used for not-supported-by-server-error
     "feature-readiness": "prontidão",  # used for not-supported-by-server-error
     "feature-managedRooms": "salas administradas",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "O recurso {} não é suportado por este servidor.",  # feature
     "shared-playlists-not-supported-by-server-error": "O recurso de playlists compartilhadas pode não ser suportado por este servidor. Para garantir que funcione corretamente, é necessário um servidor a correr Syncplay {} ou superior, mas este está correndoo Syncplay {}.",  # minVersion, serverVersion
@@ -473,6 +479,8 @@ pt_PT = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Você está usando o Syncplay {}, mas uma versão mais nova está disponível em https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate - NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Seja bem-vindo ao servidor de Syncplay, versão {0}",  # version
@@ -536,6 +544,9 @@ pt_PT = {
     "addotherusersstreamstoplaylist-menu-label": "Adicionar transmissão de {} à playlist",  # [Username]
     "openusersstream-menu-label": "Abrir transmissão de {}",  # [username]'s
     "openusersfile-menu-label": "Abrir ficheiro de {}",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Arraste um ficheiro aqui para adicioná-lo à playlist compartilhada.",
     "sharedplaylistenabled-tooltip": "Operadores da sala podem adicionar ficheiros para a playlist compartilhada para tornar mais fácil para todo mundo assistir a mesma coisa. Configure os pastas de mídia em 'Miscelânea'.",

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -61,6 +61,10 @@ ru = {
     "failed-to-identify-as-controller-notification": "{} не прошел идентификацию в качестве оператора комнаты.",
     "authenticated-as-controller-notification": "{} вошёл как оператор комнаты.",
     "created-controlled-room-notification": "Создана управляемая комната '{}' с паролем '{}'. Сохраните эти данные!\n\nВ управляемых комнатах всех синхронизируют с оператором (-ами) комнаты, только у которых есть права ставить и снимать с паузы, перематывать и изменять список воспроизведения.\n\nПопросите обычных зрителей подключиться к комнате '{}', а операторы могут подключиться к комнате '{}', чтобы автоматически авторизироваться.", # RoomName, operatorPassword, roomName, roomName:operatorPassword
+
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "Вероятно, файл, который вы смотрите, отличается от того, который смотрит {}.",  # User
     "file-differences-notification": "Ваш файл отличается: {}",  # Differences
     "room-file-differences": "Несовпадения файла: {}",  # File differences (filename, size, and/or duration)
@@ -97,6 +101,8 @@ ru = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - помощь",
     "commandlist-notification/toggle": "\tt - переключить статус готов/не готов к просмотру",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [имя комнаты] - создать управляемую комнату с таким же именем, как у текущей",
     "commandlist-notification/auth": "\ta [пароль] - авторизоваться как оператор комнаты с помощью пароля",
     "commandlist-notification/chat": "\tch [сообщение] - выслать сообщение в комнату",
@@ -157,6 +163,7 @@ ru = {
     "feature-chat": "чат",  # used for not-supported-by-server-error
     "feature-readiness": "готовность",  # used for not-supported-by-server-error
     "feature-managedRooms": "управляемые комнаты",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "Возможность '{}' не поддерживается сервером.",  # feature
     "shared-playlists-not-supported-by-server-error": "Общие списки воспроизведения могут не поддерживаться сервером. Для корректной работы требуется сервер Syncplay {}+, вы подключены к серверу Syncplay {}.",  # minVersion, serverVersion
@@ -471,6 +478,8 @@ ru = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Вы используете Syncplay версии {}. На https://syncplay.pl/ доступна более новая версия.",  # ClientVersion
     "persistent-rooms-notice": "ВНИМАНИЕ: Этот сервер использует постоянные комнаты, это означает что информация списка воспроизведения сохраняется между сеансами воспроизведения. Если вы хотите создать комнату, в которой информация не сохраняется, поставьте -temp в конце названия комнаты.",
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Добро пожаловать на сервер Syncplay версии {0}",  # version
@@ -532,6 +541,9 @@ ru = {
     "addotherusersstreamstoplaylist-menu-label": "Добавить поток {} в список воспроизведения",
     "openusersstream-menu-label": "Открыть поток {}",
     "openusersfile-menu-label": "Открыть файл {}",
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Перетащите сюда файлы, чтобы добавить их в общий список.",
     "sharedplaylistenabled-tooltip": "Оператор комнаты может добавлять файлы в список общего воспроизведения для удобного совместного просмотра. Папки воспроизведения настраиваются в меню 'Файл'.",

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -62,6 +62,9 @@ tr = {
     "authenticated-as-controller-notification": "{}, oda operatörü olarak doğrulandı",
     "created-controlled-room-notification": "Yönetilen oda '{}' '{}' şifresiyle oluşturuldu. Lütfen bu bilgileri ileride başvurmak üzere kaydedin!\n\nYönetilen odalarda, oynatma listesini duraklatabilen, devam ettirebilen, arayabilen ve değiştirebilen tek kişi olan oda operatörleri ile herkes senkronize edilir.\n\nNormal izleyicilerden '{}' odasına katılmalarını istemelisiniz, ancak oda operatörleri kendilerini otomatik olarak doğrulamak için '{}' odasına katılabilir.",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "Oynadığınız dosya, {} dosyasından farklı görünüyor",  # User
     "file-differences-notification": "Dosyanız aşağıdaki şekil(ler)de farklılık gösterir: {}",  # Differences
     "room-file-differences": "Dosya farklılıkları: {}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ tr = {
     "commandlist-notification/offset": "\to[+-]duration - offset local playback by the given duration (in seconds or min:sec) from the server seek position - this is a deprecated feature", # TODO: Translate
     "commandlist-notification/help": "\th - yardım",
     "commandlist-notification/toggle": "\tt - izlemeye hazır olup olmadığınızı değiştirir",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [name] - mevcut odanın adını kullanarak yönetilen oda oluştur",
     "commandlist-notification/auth": "\ta [password] - operatör şifresi ile oda operatörü olarak kimlik doğrular",
     "commandlist-notification/chat": "\tch [message] - bir odaya sohbet mesajı gönderir",
@@ -158,6 +163,7 @@ tr = {
     "feature-chat": "sohbet",  # used for not-supported-by-server-error
     "feature-readiness": "hazırlık",  # used for not-supported-by-server-error
     "feature-managedRooms": "yönetilen odalar",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "{} özelliği bu sunucu tarafından desteklenmiyor ..",  # feature
     "shared-playlists-not-supported-by-server-error": "Paylaşılan çalma listeleri özelliği sunucu tarafından desteklenmeyebilir. Doğru çalıştığından emin olmak için Syncplay  {}+ çalıştıran bir sunucu gerektirir, ancak sunucu Syncplay {} çalıştırmaktadır.",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ tr = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Syncplay {} kullanıyorsunuz ancak daha yeni bir sürüm https://syncplay.pl adresinde mevcut",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate - NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "Syncplay sunucusuna hoş geldiniz, ver. {0}",  # version
@@ -537,6 +545,9 @@ tr = {
     "addotherusersstreamstoplaylist-menu-label": "Oynatma listesine {} kişisinin akışını ekleyin",  # [Username]
     "openusersstream-menu-label": "{} kişisinin akışını açın",  # [username]'s
     "openusersfile-menu-label": "{} kişisinin dosyasını açın",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "Dosyayı paylaşılan çalma listesine eklemek için buraya sürükleyin.",
     "sharedplaylistenabled-tooltip": "Oda operatörleri, herkesin aynı şeyi izlemesini kolaylaştırmak için senkronize edilmiş bir çalma listesine dosya ekleyebilir. 'Misc' altında ortam dizinlerini yapılandırın.",

--- a/syncplay/messages_zh_CN.py
+++ b/syncplay/messages_zh_CN.py
@@ -62,6 +62,9 @@ zh_CN = {
     "authenticated-as-controller-notification": "{}成为了管理员",
     "created-controlled-room-notification": "已创建房间：'{}' ，密码是'{}'。请保存好以上信息以备用！\n\n只有房主或管理员可以暂停，继续播放，跳转播放，改变播放列表。每个人都与房主或管理员的播放进度同步。\n\n最近观看过的人都可加入'{}'房间，但只有房主或管理员在加入'{}'房间时才会自动认证为管理员。",  # RoomName, operatorPassword, roomName, roomName:operatorPassword
 
+    "other-set-as-ready-notification": "{} was set as ready by {}",  # User set as ready, user who set them as ready # TODO: Translate
+    "other-set-as-not-ready-notification": "{} was set as not ready by {}", # User set as not ready, user who set them as not ready # TODO: Translate
+
     "file-different-notification": "您正在播放的视频与{}不一致",  # User
     "file-differences-notification": "你们播放的视频文件{}不一致",  # Differences
     "room-file-differences": "播放文件不同点：{}",  # File differences (filename, size, and/or duration)
@@ -98,6 +101,8 @@ zh_CN = {
     "commandlist-notification/offset": "\to[+-]duration - 将本地的播放偏移量设置为给定时长（输入格式可为秒或分：秒），您的本地播放进度将与服务器不一致，因此极不推荐使用该设置",
     "commandlist-notification/help": "\th - 帮助菜单",
     "commandlist-notification/toggle": "\tt - 准备/取消准备",
+    "commandlist-notification/setready": "\tsr [name] - sets user as ready",  # TODO: Translate
+    "commandlist-notification/setnotready": "\tsn [name] - sets user as not ready",  # TODO: Translate
     "commandlist-notification/create": "\tc [name] - 以给定房间名创建一个由您管理的房间",
     "commandlist-notification/auth": "\ta [password] - 用给定密码来认证为管理员",
     "commandlist-notification/chat": "\tch [message] - 发送聊天信息",
@@ -158,6 +163,7 @@ zh_CN = {
     "feature-chat": "聊天",  # used for not-supported-by-server-error
     "feature-readiness": "准备状态",  # used for not-supported-by-server-error
     "feature-managedRooms": "房间管理",  # used for not-supported-by-server-error
+    "feature-setOthersReadiness": "readiness override",  # used for not-supported-by-server-error # TODO: Translate
 
     "not-supported-by-server-error": "该服务器不支持{}功能",  # feature
     "shared-playlists-not-supported-by-server-error": "服务器可能不支持共享播放列表的功能。为确保其正常运行，需要一个运行Syncplay {}以上版本的服务器，但服务器是运行Syncplay {}的。",  # minVersion, serverVersion
@@ -474,6 +480,8 @@ zh_CN = {
     # Server messages to client
     "new-syncplay-available-motd-message": "您正在使用Syncplay {}版本，但已有较新的版本可从https://syncplay.pl下载。",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # NOTE: Do not translate the word -temp
+    "ready-chat-message": "I have set {} as ready.",  # User # TODO: Translate
+    "not-ready-chat-message": "I have set {} as not ready.",  # User # TODO: Translate
 
     # Server notifications
     "welcome-server-notification": "欢迎使用Syncplay服务端，当前版本{0}",  # version
@@ -537,6 +545,9 @@ zh_CN = {
     "addotherusersstreamstoplaylist-menu-label": "添加{}的媒体流流到播放列表",  # [Username]
     "openusersstream-menu-label": "打开{}的媒体流",  # [username]'s
     "openusersfile-menu-label": "打开{}的文件",  # [username]'s
+
+    "setasready-menu-label": "Set {} as ready",  # [Username] # TODO: Translate
+    "setasnotready-menu-label": "Set {} as not ready",  # [Username] # TODO: Translate
 
     "playlist-instruction-item-message": "把文件拖到这里，就可以把它添加到共享播放列表中。",
     "sharedplaylistenabled-tooltip": "房间管理员可以将文件添加到共享播放列表中，以方便大家观看同样的东西。可以在其他设置中配置媒体目录。",

--- a/syncplay/players/mpc.py
+++ b/syncplay/players/mpc.py
@@ -407,7 +407,7 @@ class MPCHCAPIPlayer(BasePlayer):
 
     def openFile(self, filePath, resetPosition=False):
         self._mpcApi.openFile(filePath)
-        if resetPosition:
+        if resetPosition and self._mpcApi.filePlaying:
             self.setPosition(0, resetPosition=True)
 
     def displayMessage(

--- a/syncplay/protocols.py
+++ b/syncplay/protocols.py
@@ -201,7 +201,8 @@ class SyncClientProtocol(JSONCommandProtocol):
             elif command == "ready":
                 user, isReady = values["username"], values["isReady"]
                 manuallyInitiated = values["manuallyInitiated"] if "manuallyInitiated" in values else True
-                self._client.setReady(user, isReady, manuallyInitiated)
+                setBy = values["setBy"] if "setBy" in values else None
+                self._client.setReady(user, isReady, manuallyInitiated, setBy)
             elif command == "playlistIndex":
                 user = values['user']
                 resetPosition = True
@@ -330,13 +331,22 @@ class SyncClientProtocol(JSONCommandProtocol):
         userMessage = message['message']
         self._client.ui.showChatMessage(username, userMessage)
 
-    def setReady(self, isReady, manuallyInitiated=True):
-        self.sendSet({
-            "ready": {
-                "isReady": isReady,
-                "manuallyInitiated": manuallyInitiated
-            }
-        })
+    def setReady(self, isReady, manuallyInitiated=True, username=None):
+        if username:
+            self.sendSet({
+                "ready": {
+                    "isReady": isReady,
+                    "manuallyInitiated": manuallyInitiated,
+                    "username": username
+                }
+            })
+        else:
+            self.sendSet({
+                "ready": {
+                    "isReady": isReady,
+                    "manuallyInitiated": manuallyInitiated
+                }
+            })
 
     def setPlaylist(self, files):
         self.sendSet({
@@ -566,7 +576,8 @@ class SyncServerProtocol(JSONCommandProtocol):
                 self._factory.authRoomController(self._watcher, password, room)
             elif command == "ready":
                 manuallyInitiated = set_[1]['manuallyInitiated'] if "manuallyInitiated" in set_[1] else False
-                self._factory.setReady(self._watcher, set_[1]['isReady'], manuallyInitiated=manuallyInitiated)
+                username = set_[1]['username'] if "username" in set_[1] else None
+                self._factory.setReady(self._watcher, set_[1]['isReady'], manuallyInitiated=manuallyInitiated, username=username)
             elif command == "playlistChange":
                 self._factory.setPlaylist(self._watcher, set_[1]['files'])
             elif command == "playlistIndex":
@@ -595,14 +606,24 @@ class SyncServerProtocol(JSONCommandProtocol):
             }
         })
 
-    def sendSetReady(self, username, isReady, manuallyInitiated=True):
-        self.sendSet({
-            "ready": {
-                "username": username,
-                "isReady": isReady,
-                "manuallyInitiated": manuallyInitiated
-            }
-        })
+    def sendSetReady(self, username, isReady, manuallyInitiated=True, setByUsername=None):
+        if setByUsername:
+            self.sendSet({
+                "ready": {
+                    "username": username,
+                    "isReady": isReady,
+                    "manuallyInitiated": manuallyInitiated,
+                    "setBy": setByUsername
+                }
+            })
+        else:
+            self.sendSet({
+                "ready": {
+                    "username": username,
+                    "isReady": isReady,
+                    "manuallyInitiated": manuallyInitiated
+                }
+            })
 
     def setPlaylist(self, username, files):
         self.sendSet({

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -97,6 +97,7 @@ class SyncFactory(Factory):
         features["maxUsernameLength"] = self.maxUsernameLength
         features["maxRoomNameLength"] = constants.MAX_ROOM_NAME_LENGTH
         features["maxFilenameLength"] = constants.MAX_FILENAME_LENGTH
+        features["setOthersReadiness"] = True
 
         return features
 
@@ -213,9 +214,22 @@ class SyncFactory(Factory):
         messageDict = {"message": message, "username": watcher.getName()}
         self._roomManager.broadcastRoom(watcher, lambda w: w.sendChatMessage(messageDict))
 
-    def setReady(self, watcher, isReady, manuallyInitiated=True):
-        watcher.setReady(isReady)
-        self._roomManager.broadcastRoom(watcher, lambda w: w.sendSetReady(watcher.getName(), watcher.isReady(), manuallyInitiated))
+    def setReady(self, watcher, isReady, manuallyInitiated=True, username=None):
+        if username and username != watcher.getName():
+            room = watcher.getRoom()
+            if room.canControl(watcher):
+                for watcherToSet in room.getWatchers():
+                    if watcherToSet.getName() == username:
+                        watcherToSet.setReady(isReady)
+                        self._roomManager.broadcastRoom(watcherToSet, lambda w: w.sendSetReady(watcherToSet.getName(), watcherToSet.isReady(),  manuallyInitiated, watcher.getName()))
+                        if isReady:
+                            messageDict = { "message": getMessage("ready-chat-message").format(username, watcherToSet.getName()), "username": watcher.getName()}
+                        else:
+                            messageDict = {"message": getMessage("not-ready-chat-message").format(username, watcherToSet.getName()), "username": watcher.getName()}
+                        self._roomManager.broadcastRoom(watcher, lambda w: w.sendChatMessage(messageDict, "setOthersReadiness"))
+        else:
+            watcher.setReady(isReady)
+            self._roomManager.broadcastRoom(watcher, lambda w: w.sendSetReady(watcher.getName(), watcher.isReady(), manuallyInitiated))
 
     def setPlaylist(self, watcher, files):
         room = watcher.getRoom()
@@ -777,8 +791,10 @@ class Watcher(object):
     def sendControlledRoomAuthStatus(self, success, username, room):
         self._connector.sendControlledRoomAuthStatus(success, username, room)
 
-    def sendChatMessage(self, message):
+    def sendChatMessage(self, message, skipIfSupportsFeature):
         if self._connector.meetsMinVersion(constants.CHAT_MIN_VERSION):
+            if skipIfSupportsFeature and self.supportsFeature(skipIfSupportsFeature):
+                return
             self._connector.sendMessage({"Chat": message})
 
     def sendList(self, toGUIOnly=False):
@@ -798,8 +814,12 @@ class Watcher(object):
             uiMode = constants.FALLBACK_ASSUMED_UI_MODE
         return uiMode == constants.GRAPHICAL_UI_MODE
 
-    def sendSetReady(self, username, isReady, manuallyInitiated=True):
-        self._connector.sendSetReady(username, isReady, manuallyInitiated)
+    def supportsFeature(self, clientFeature):
+        clientFeatures = self._connector.getFeatures()
+        return clientFeatures[clientFeature] if clientFeature in clientFeatures else False
+
+    def sendSetReady(self, username, isReady, manuallyInitiated=True, setByUsername=None):
+        self._connector.sendSetReady(username, isReady, manuallyInitiated, setByUsername)
 
     def setPlaylistIndex(self, username, index):
         self._connector.setPlaylistIndex(username, index)

--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -791,7 +791,7 @@ class Watcher(object):
     def sendControlledRoomAuthStatus(self, success, username, room):
         self._connector.sendControlledRoomAuthStatus(success, username, room)
 
-    def sendChatMessage(self, message, skipIfSupportsFeature):
+    def sendChatMessage(self, message, skipIfSupportsFeature=None):
         if self._connector.meetsMinVersion(constants.CHAT_MIN_VERSION):
             if skipIfSupportsFeature and self.supportsFeature(skipIfSupportsFeature):
                 return

--- a/syncplay/ui/consoleUI.py
+++ b/syncplay/ui/consoleUI.py
@@ -231,6 +231,20 @@ class ConsoleUI(threading.Thread):
         elif command.group('command') in constants.COMMANDS_NEXT:
             self._syncplayClient.playlist.loadNextFileInPlaylist()
 
+        elif command.group('command') in constants.COMMANDS_SETREADY:
+            try:
+                username = command.group('parameter')
+                self._syncplayClient.setOthersReadiness(username, True)
+            except:
+                pass
+
+        elif command.group('command') in constants.COMMANDS_SETNOTREADY:
+            try:
+                username = command.group('parameter')
+                self._syncplayClient.setOthersReadiness(username, False)
+            except:
+                pass
+
         else:
             if self._tryAdvancedCommands(data):
                 return

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -820,16 +820,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 if path:
                     menu.addAction(QtGui.QPixmap(resourcespath + "folder_film.png"), getMessage('open-containing-folder'), lambda: utils.open_system_file_browser(path))
 
-
-        if roomToJoin == self._syncplayClient.getRoom() and self._syncplayClient.userlist.currentUser.canControl() and self._syncplayClient.userlist.isReadinessSupported() and self._syncplayClient.serverFeatures["setOthersReadiness"]:
+        if roomToJoin == self._syncplayClient.getRoom() and self._syncplayClient.userlist.currentUser.canControl() and self._syncplayClient.userlist.isReadinessSupported(requiresOtherUsers=False) and self._syncplayClient.serverFeatures["setOthersReadiness"]:
             if self._syncplayClient.userlist.isReady(username):
                 addSetUserAsReadyText = getMessage("setasnotready-menu-label").format(shortUsername)
                 menu.addAction(QtGui.QPixmap(resourcespath + "cross.png"), addSetUserAsReadyText, lambda: self._syncplayClient.setOthersReadiness(username, False))
             else:
                 addSetUserAsNotReadyText = getMessage("setasnotready-menu-label").format(shortUsername)
                 menu.addAction(QtGui.QPixmap(resourcespath + "tick.png"), addSetUserAsNotReadyText, lambda: self._syncplayClient.setOthersReadiness(username, True))
-        else:
-            return
         menu.exec_(self.listTreeView.viewport().mapToGlobal(position))
 
     def updateListGeometry(self):

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -819,6 +819,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 path = self._syncplayClient.fileSwitch.findFilepath(filename)
                 if path:
                     menu.addAction(QtGui.QPixmap(resourcespath + "folder_film.png"), getMessage('open-containing-folder'), lambda: utils.open_system_file_browser(path))
+
+
+        if roomToJoin == self._syncplayClient.getRoom() and self._syncplayClient.userlist.currentUser.canControl() and self._syncplayClient.userlist.isReadinessSupported() and self._syncplayClient.serverFeatures["setOthersReadiness"]:
+            if self._syncplayClient.userlist.isReady(username):
+                addSetUserAsReadyText = getMessage("setasnotready-menu-label").format(shortUsername)
+                menu.addAction(QtGui.QPixmap(resourcespath + "cross.png"), addSetUserAsReadyText, lambda: self._syncplayClient.setOthersReadiness(username, False))
+            else:
+                addSetUserAsNotReadyText = getMessage("setasnotready-menu-label").format(shortUsername)
+                menu.addAction(QtGui.QPixmap(resourcespath + "tick.png"), addSetUserAsNotReadyText, lambda: self._syncplayClient.setOthersReadiness(username, True))
         else:
             return
         menu.exec_(self.listTreeView.viewport().mapToGlobal(position))


### PR DESCRIPTION
This feature allows a user who can control a room to set someone else in the room to be ready or not ready.

Useful for if someone forgets to change their status or if someone is on voice chat but is away from their keyboard and wants others to update their readiness status.

Requires server to be running latest development build, so can't be tested on public server until that has been updated.