### PR TITLE
Fix invalid string escapes

### DIFF
--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -112,9 +112,9 @@ FOLDER_SEARCH_DOUBLE_CHECK_INTERVAL = 30.0  # Secs - Frequency of updating cache
 # Usually there's no need to adjust these
 DOUBLE_CHECK_REWIND = False
 LAST_PAUSED_DIFF_THRESHOLD = 2
-FILENAME_STRIP_REGEX = "[-~_\.\[\](): ]"
-CONTROL_PASSWORD_STRIP_REGEX = "[^a-zA-Z0-9\-]"
-ROOM_NAME_STRIP_REGEX = "^(\+)(?P<roomnamebase>.*)(:)(\w{12})$"
+FILENAME_STRIP_REGEX = r"[-~_\.\[\](): ]"
+CONTROL_PASSWORD_STRIP_REGEX = r"[^a-zA-Z0-9\-]"
+ROOM_NAME_STRIP_REGEX = r"^(\+)(?P<roomnamebase>.*)(:)(\w{12})$"
 ARGUMENT_SPLIT_REGEX = r'(?:[^\s"]+|"[^"]*")+'
 COMMANDS_UNDO = ["u", "undo", "revert"]
 COMMANDS_CHAT = ["ch", "chat"]
@@ -163,7 +163,7 @@ MPC_PATHS = [
 ]
 
 MPC_EXECUTABLES = ["mpc-hc.exe", "mpc-hc64.exe", "mpc-hcportable.exe", "mpc-hc_nvo.exe", "mpc-hc64_nvo.exe", "shoukaku.exe"]
-MPC64_EXECUTABLES = ["mpc-hc64.exe", "mpc-hc64_nvo.exe", "x64\mpc-hc\shoukaku.exe"]
+MPC64_EXECUTABLES = ["mpc-hc64.exe", "mpc-hc64_nvo.exe", r"x64\mpc-hc\shoukaku.exe"]
 
 MPC_BE_PATHS = [
     r"c:\program files\mpc-be x64\mpc-be64.exe",
@@ -302,7 +302,7 @@ VLC_SLAVE_EXTRA_ARGS = getValueForOS({
      OS_MACOS: ['--verbose=2', '--no-file-logging']})
 MPV_SUPERSEDE_IF_DUPLICATE_COMMANDS = ["set_property time-pos ", "loadfile "]
 MPV_REMOVE_BOTH_IF_DUPLICATE_COMMANDS = ["cycle pause"]
-MPLAYER_ANSWER_REGEX = "^ANS_([a-zA-Z_-]+)=(.+)$|^(Exiting)\.\.\. \((.+)\)$"
+MPLAYER_ANSWER_REGEX = r"^ANS_([a-zA-Z_-]+)=(.+)$|^(Exiting)\.\.\. \((.+)\)$"
 VLC_ANSWER_REGEX = r"(?:^(?P<command>[a-zA-Z_-]+)(?:\: )?(?P<argument>.*))"
 UI_COMMAND_REGEX = r"^(?P<command>[^\ ]+)(?:\ (?P<parameter>.+))?"
 UI_OFFSET_REGEX = r"^(?:o|offset)\ ?(?P<sign>[/+-])?(?P<time>\d{1,9}(?:[^\d\.](?:\d{1,9})){0,2}(?:\.(?:\d{1,3}))?)$"

--- a/syncplay/utils.py
+++ b/syncplay/utils.py
@@ -306,7 +306,7 @@ def stripfilename(filename, stripURL):
 def stripRoomName(RoomName):
     if RoomName:
         try:
-            return re.sub(constants.ROOM_NAME_STRIP_REGEX, "\g<roomnamebase>", RoomName)
+            return re.sub(constants.ROOM_NAME_STRIP_REGEX, r"\g<roomnamebase>", RoomName)
         except IndexError:
             return RoomName
     else:
@@ -484,8 +484,8 @@ def getListOfPublicServers():
 
 
 class RoomPasswordProvider(object):
-    CONTROLLED_ROOM_REGEX = re.compile("^\+(.*):(\w{12})$")
-    PASSWORD_REGEX = re.compile("[A-Z]{2}-\d{3}-\d{3}")
+    CONTROLLED_ROOM_REGEX = re.compile(r"^\+(.*):(\w{12})$")
+    PASSWORD_REGEX = re.compile(r"[A-Z]{2}-\d{3}-\d{3}")
 
     @staticmethod
     def isControlledRoom(roomName):


### PR DESCRIPTION
```
/usr/lib/syncplay/syncplay/utils.py:330: SyntaxWarning: invalid escape sequence '\g'
  return re.sub(constants.ROOM_NAME_STRIP_REGEX, "\g<roomnamebase>", RoomName)
/usr/lib/syncplay/syncplay/utils.py:508: SyntaxWarning: invalid escape sequence '\+'
  CONTROLLED_ROOM_REGEX = re.compile("^\+(.*):(\w{12})$")
/usr/lib/syncplay/syncplay/utils.py:509: SyntaxWarning: invalid escape sequence '\d'
  PASSWORD_REGEX = re.compile("[A-Z]{2}-\d{3}-\d{3}")
/usr/lib/syncplay/syncplay/constants.py:115: SyntaxWarning: invalid escape sequence '\.'
  FILENAME_STRIP_REGEX = "[-~_\.\[\](): ]"
/usr/lib/syncplay/syncplay/constants.py:116: SyntaxWarning: invalid escape sequence '\-'
  CONTROL_PASSWORD_STRIP_REGEX = "[^a-zA-Z0-9\-]"
/usr/lib/syncplay/syncplay/constants.py:117: SyntaxWarning: invalid escape sequence '\+'
  ROOM_NAME_STRIP_REGEX = "^(\+)(?P<roomnamebase>.*)(:)(\w{12})$"
/usr/lib/syncplay/syncplay/constants.py:166: SyntaxWarning: invalid escape sequence '\m'
  MPC64_EXECUTABLES = ["mpc-hc64.exe", "mpc-hc64_nvo.exe", "x64\mpc-hc\shoukaku.exe"]
/usr/lib/syncplay/syncplay/constants.py:305: SyntaxWarning: invalid escape sequence '\.'
  MPLAYER_ANSWER_REGEX = "^ANS_([a-zA-Z_-]+)=(.+)$|^(Exiting)\.\.\. \((.+)\)$"
```