### PR TITLE
Allow `@` keyind to be used (mpv Next Chapter)

### DIFF
--- a/syncplay/resources/syncplayintf.lua
+++ b/syncplay/resources/syncplayintf.lua
@@ -965,7 +965,6 @@ add_alpharowbinding('[',']')
 add_alpharowbinding('#','#')
 add_alpharowbinding('~','~')
 add_alpharowbinding('\'','\'')
-add_alpharowbinding('@','@')
 
 add_specialalphabindings(non_us_chars)
 add_repl_bindings(bindings)


### PR DESCRIPTION
This allows the default keybind for Next Chapter in mpv to be used when the option to automatically chat is enabled.