### PR TITLE
Fix invocation of get font dialog

### DIFF
--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -1128,7 +1128,7 @@ class ConfigDialog(QtWidgets.QDialog):
             font = QtGui.QFont()
             font.setFamily(self.config[configName + "FontFamily"])
             font.setPointSize(self.config[configName + "RelativeFontSize"])
-            font.setWeight(self.config[configName + "FontWeight"])
+            font.setLegacyWeight(self.config[configName + "FontWeight"])
             font.setUnderline(self.config[configName + "FontUnderline"])
             ok, value = QtWidgets.QFontDialog.getFont(font)
             if ok:


### PR DESCRIPTION
Fixes the following traceback when opening the get font dialog through Chat -> Set Font:
```python
Traceback (most recent call last):
  File "/home/username/syncplay/syncplay/ui/GuiConfiguration.py", line 1030, in <lambda>
    self.chatInputFontButton.released.connect(lambda: self.fontDialog("chatInput"))
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/username/syncplay/syncplay/ui/GuiConfiguration.py", line 1131, in fontDialog
    font.setWeight(self.config[configName + "FontWeight"])
TypeError: 'PySide6.QtGui.QFont.setWeight' called with wrong argument types:
  PySide6.QtGui.QFont.setWeight(float)
Supported signatures:
  PySide6.QtGui.QFont.setWeight(PySide6.QtGui.QFont.Weight)
```