### PR TITLE
Special-case MOTD in showMessage procedures.

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -1687,10 +1687,10 @@ class UiManager(object):
     def setSSLMode(self, sslMode, sslInformation=""):
         self.__ui.setSSLMode(sslMode, sslInformation)
 
-    def showMessage(self, message, noPlayer=False, noTimestamp=False, OSDType=constants.OSD_NOTIFICATION, mood=constants.MESSAGE_NEUTRAL):
+    def showMessage(self, message, noPlayer=False, noTimestamp=False, OSDType=constants.OSD_NOTIFICATION, mood=constants.MESSAGE_NEUTRAL, isMotd=False):
         if not noPlayer:
             self.showOSDMessage(message, duration=constants.OSD_DURATION, OSDType=OSDType, mood=mood)
-        self.__ui.showMessage(message, noTimestamp)
+        self.__ui.showMessage(message, noTimestamp=noTimestamp, isMotd=isMotd)
 
     def updateAutoPlayState(self, newState):
         self.__ui.updateAutoPlayState(newState)

--- a/syncplay/protocols.py
+++ b/syncplay/protocols.py
@@ -145,7 +145,7 @@ class SyncClientProtocol(JSONCommandProtocol):
                 motd += "\n\n"
             motd += getMessage("persistent-rooms-notice")
         if motd:
-            self._client.ui.showMessage(motd, True, True)
+            self._client.ui.showMessage(motd, noPlayer=True, noTimestamp=True, isMotd=True)
         self._client.ui.showMessage(getMessage("connected-successful-notification"))
         self._client.connected()
         self._client.sendFile()

--- a/syncplay/ui/consoleUI.py
+++ b/syncplay/ui/consoleUI.py
@@ -99,7 +99,7 @@ class ConsoleUI(threading.Thread):
     def setFeatures(self, featureList):
         pass
 
-    def showMessage(self, message, noTimestamp=False):
+    def showMessage(self, message, noTimestamp=False, isMotd=False):
         message = message.encode(sys.stdout.encoding, 'replace')
         try:
             message = message.decode('utf-8')

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -49,8 +49,8 @@ else:
 
 
 class ConsoleInGUI(ConsoleUI):
-    def showMessage(self, message, noTimestamp=False):
-        self._syncplayClient.ui.showMessage(message, True)
+    def showMessage(self, message, noTimestamp=False, isMotd=False):
+        self._syncplayClient.ui.showMessage(message, noTimestamp=True, isMotd=isMotd)
 
     def showDebugMessage(self, message):
         self._syncplayClient.ui.showDebugMessage(message)
@@ -542,7 +542,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def getSSLInformation(self):
         return self.sslInformation
 
-    def showMessage(self, message, noTimestamp=False):
+    def showMessage(self, message, noTimestamp=False, isMotd=False):
         message = str(message)
         username = None
         messageWithUsername = re.match(constants.MESSAGE_WITH_USERNAME_REGEX, message, re.UNICODE)
@@ -552,6 +552,10 @@ class MainWindow(QtWidgets.QMainWindow):
         message = message.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
         if username:
             message = constants.STYLE_USER_MESSAGE.format(constants.STYLE_USERNAME, username, message)
+        # When showing a MOTD, escape spaces and use a monospace font to preserve the look of ASCII art.
+        if isMotd:
+            message = message.replace(" ", "&nbsp;")
+            message = "<code>{}</code>".format(message)
         message = message.replace("\n", "<br />")
         if noTimestamp:
             self.newMessage("{}<br />".format(message))


### PR DESCRIPTION
Hello, for a MOTD it is natural to use ASCII art but since messages in the chat box are added using QT's HTML-like text fragments, multiple spaces are merged together and the default variable-width font destroys alignment.

<table>
<tr>
<td>default look:</td>
<td>desired look:</td>
</tr><tr><td>

![broken](https://github.com/user-attachments/assets/76c2a866-41aa-4752-99e9-90e3aa45a5a7)

</td><td>

![correct](https://github.com/user-attachments/assets/046c1f81-76de-441c-9f58-a4309c64c604)

</td></tr></table>

Therefore, I propose that when showing a MOTD we escape spaces with `&nbsp;` and wrap everything in `<code>` tags to select a monospace font.

One problem is that MOTD is also used for showing warnings to the user, such as the "new-syncplay-available-motd-message" message. These will also be changed accordingly. If undesired, these warning should be sent in a separate field.

I have only tested this on openSUSE with python 3.11.11 and PySide6 6.8.0.2 so far. I assume that `<code>` tags work in every python QT library since they are supported by the rich text engine (https://doc.qt.io/qtforpython-5/overviews/richtext-html-subset.html#supported-html-subset). Is there a standard way to test for the different QT wrapper libraries that should be supported?