### PR TITLE
Instead of localhost, use 127.0.0.1 (Fixes #302)

### DIFF
--- a/syncplay/players/vlc.py
+++ b/syncplay/players/vlc.py
@@ -528,7 +528,7 @@ class VlcPlayer(BasePlayer):
                 vlcoutputthread.start()
             self.__playerController._vlcready.clear()
             self._factory = VLCClientFactory(self.__playerController, self.vlcHasResponded, self.timeVLCLaunched, self.__process)
-            self.reactor.connectTCP('localhost', self.__playerController.vlcport, self._factory)
+            self.reactor.connectTCP('127.0.0.1', self.__playerController.vlcport, self._factory)
 
         def _shouldListenForSTDOUT(self):
             return not isWindows()

--- a/syncplay/resources/lua/intf/syncplay.lua
+++ b/syncplay/resources/lua/intf/syncplay.lua
@@ -90,7 +90,7 @@ local durationdelay = 500000 -- Pause for get_duration command etc for increased
 local loopsleepduration = 2500 -- Pause for every event loop (uses microseconds)
 local quitcheckfrequency = 20 -- Check whether VLC has closed every X loops
 
-local host = "localhost"
+local host = "127.0.0.1"
 local port
 
 local titlemultiplier = 604800 -- One week


### PR DESCRIPTION
In issue #302 on MacOS (and presumably Linux), a wrongly configured hosts file can result in localhost not resolving

MacOS will for the most part function fine without it, allowing the system to otherwise function acceptably, while syncplay fails to work using VLC.

This change is slightly questionable though, as it could be said not having a definition of localhost is a failure on the operator of the system's part. 

Feel free to reject this PR in that case.