### PR TITLE
TLS: fix loading only the first certificate in chain

### DIFF
--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -250,15 +250,18 @@ class SyncFactory(Factory):
 
     def _allowTLSconnections(self, path):
         try:
-            privKey = open(path+'/privkey.pem', 'rt').read()
-            certif = open(path+'/cert.pem', 'rt').read()
-            chain = open(path+'/chain.pem', 'rt').read()
+            privKey = open(path+'/privkey.pem', 'rb').read()
+            certif = open(path+'/cert.pem', 'rb').read()
+            chain = open(path+'/chain.pem', 'rb').read()
 
             self.lastEditCertTime = os.path.getmtime(path+'/cert.pem')
 
             privKeyPySSL = crypto.load_privatekey(crypto.FILETYPE_PEM, privKey)
             certifPySSL = crypto.load_certificate(crypto.FILETYPE_PEM, certif)
-            chainPySSL = [crypto.load_certificate(crypto.FILETYPE_PEM, chain)]
+
+            sentinel = b'-----BEGIN CERTIFICATE-----'
+            chainPySSL = [crypto.load_certificate(crypto.FILETYPE_PEM, sentinel + chain_cert) for chain_cert in
+                          chain.split(sentinel)[1:]]
 
             cipherListString = "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"\
                                "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"\


### PR DESCRIPTION
Fixes #749. The Syncplay server would originally only load the first certificate in the chain, but the chain file can contain multiple certs. This was what was happening with the `classic` vs `tlsserver` profile, as the certs generated by letsencrypt's `classic` would contain 1 chain cert whereas letsencrypt's `tlsserver` profile would contain 3. 