### PR TITLE
syncplayintf.lua: update `non_us_chars`  variable to include ukrainian letters

### DIFF
--- a/syncplay/resources/syncplayintf.lua
+++ b/syncplay/resources/syncplayintf.lua
@@ -85,6 +85,7 @@ non_us_chars = {
     '~', 'ẽ', 'ĩ', 'ũ',
     '¨',
     'ő', 'ű', 'Ő', 'Ű',
+    'Ґ', 'ґ', 'Є', 'є', 'І', 'і', 'Ї', 'ї',
 }
 
 function format_scrolling(xpos, ypos, text)


### PR DESCRIPTION
Closes: https://github.com/Syncplay/syncplay/issues/748