### PR TITLE
Add IME input support for mpv chat via mp.input API

### DIFF
--- a/syncplay/constants.py
+++ b/syncplay/constants.py
@@ -273,6 +273,7 @@ MPV_ARGS = {'force-window': 'yes',
             'hr-seek': 'always',
             'keep-open': 'always',
             'input-terminal': 'no',
+            'input-ime': 'yes',
             'term-playing-msg': '<SyncplayUpdateFile>\nANS_filename=${filename}\nANS_length=${=duration:${=length:0}}\nANS_path=${path}\n</SyncplayUpdateFile>',
             'keep-open-pause': 'yes'
             }


### PR DESCRIPTION
## Summary
- Uses mpv's native `mp.input.get()` text input API (mpv 0.39+) for chat, which properly supports IME composition for Chinese, Japanese, Korean and other input methods
- Falls back to existing key-binding system for older mpv versions — no behavior change for users on mpv < 0.39
- Enables `--input-ime=yes` in mpv launch args (mpv defaults to `no` on Windows)


Closes #732