### PR TITLE
Add missing translation strings across all non-English languages

### DIFF
--- a/syncplay/messages_de.py
+++ b/syncplay/messages_de.py
@@ -25,6 +25,10 @@ de = {
 
     "connection-attempt-notification": "Verbinde mit {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Verbindung zum Server verloren, versuche erneut",
+    "reconnect-menu-triggered-notification": "Manuelle Neuverbindung eingeleitet - neuer Verbindungsversuch zu {}:{} in 2 Sekunden...",
+    "reconnect-failed-no-host-error": "Neuverbindung nicht möglich: keine Serverinformationen verfügbar",
+    "reconnect-failed-no-port-error": "Neuverbindung nicht möglich: ungültige Serverkonfiguration",
+    "reconnect-failed-error": "Neuverbindung fehlgeschlagen: {}",
     "disconnection-notification": "Verbindung zum Server beendet",
     "connection-failed-notification": "Verbindung zum Server fehlgeschlagen",
     "connected-successful-notification": "Erfolgreich mit Server verbunden",
@@ -330,6 +334,7 @@ de = {
     "setmediadirectories-menu-label": "Medienverzeichnisse &auswählen",
     "loadplaylistfromfile-menu-label": "&Lade Playlist aus Datei",
     "saveplaylisttofile-menu-label": "&Speichere Playlist in Datei",
+    "reconnect-menu-label": "&Erneut mit Server verbinden",
     "exit-menu-label": "&Beenden",
     "advanced-menu-label": "&Erweitert",
     "window-menu-label": "&Fenster",

--- a/syncplay/messages_eo.py
+++ b/syncplay/messages_eo.py
@@ -27,6 +27,10 @@ eo = {
 
     "connection-attempt-notification": "Provas konektiĝi al {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Konekto al servilo perdiĝis; provas rekonektiĝi",
+    "reconnect-menu-triggered-notification": "Mana rekonekto iniciatita - provos novan konekton al {}:{} post 2 sekundoj...",
+    "reconnect-failed-no-host-error": "Ne eblas rekonektiĝi: neniu servila informo disponebla",
+    "reconnect-failed-no-port-error": "Ne eblas rekonektiĝi: nevalida servila agordo",
+    "reconnect-failed-error": "Rekonekto malsukcesis: {}",
     "disconnection-notification": "Malkonektiĝis de servilo",
     "connection-failed-notification": "Konekto al servilo malsukcesis",
     "connected-successful-notification": "Sukcese konektiĝis al servilo",
@@ -337,6 +341,7 @@ eo = {
     "setmediadirectories-menu-label": "Agordi vidaŭdajn dosier&ujojn",
     "loadplaylistfromfile-menu-label": "&Enlegi ludliston de dosiero",
     "saveplaylisttofile-menu-label": "&Konservi ludliston al dosiero",
+    "reconnect-menu-label": "&Rekonektiĝi al servilo",
     "exit-menu-label": "Ĉesi&gi la programon",
     "advanced-menu-label": "&Altnivelaj",
     "window-menu-label": "&Fenestro",

--- a/syncplay/messages_es.py
+++ b/syncplay/messages_es.py
@@ -25,6 +25,10 @@ es = {
 
     "connection-attempt-notification": "Intentando conectarse a {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Se perdió la conexión con el servidor, intentando reconectar",
+    "reconnect-menu-triggered-notification": "Reconexión manual iniciada - se intentará una nueva conexión a {}:{} en 2 segundos...",
+    "reconnect-failed-no-host-error": "No se puede reconectar: no hay información del servidor disponible",
+    "reconnect-failed-no-port-error": "No se puede reconectar: configuración del servidor inválida",
+    "reconnect-failed-error": "Reconexión fallida: {}",
     "disconnection-notification": "Desconectado del servidor",
     "connection-failed-notification": "La conexión con el servidor falló",
     "connected-successful-notification": "Conectado al servidor exitosamente",
@@ -333,6 +337,7 @@ es = {
     "setmediadirectories-menu-label": "&Establecer directorios de medios",
     "loadplaylistfromfile-menu-label": "&Load playlist from file",  # TODO: Translate
     "saveplaylisttofile-menu-label": "&Save playlist to file",  # TODO: Translate
+    "reconnect-menu-label": "&Reconectar al servidor",
     "exit-menu-label": "&Salir",
     "advanced-menu-label": "A&vanzado",
     "window-menu-label": "&Ventana",
@@ -480,6 +485,8 @@ es = {
     # Server messages to client
     "new-syncplay-available-motd-message": "Estás usando Syncplay {} pero hay una versión más nueva disponible en https://syncplay.pl",  # ClientVersion
     "persistent-rooms-notice": "NOTICE: This server uses persistent rooms, which means that the playlist information is stored between playback sessions. If you want to create a room where information is not saved then put -temp at the end of the room name.", # TO DO: Translate - NOTE: Do not translate the word -temp
+    "ready-chat-message": "He marcado a {} como listo.",  # User
+    "not-ready-chat-message": "He marcado a {} como no listo.",  # User
 
     # Server notifications
     "welcome-server-notification": "Bienvenido al servidor de Syncplay, ver. {0}",  # version

--- a/syncplay/messages_fi.py
+++ b/syncplay/messages_fi.py
@@ -25,6 +25,10 @@ fi = {
 
      "connection-attempt-notification": "Yritetään yhdistää kohteeseen {}:{}",  # Port, IP
      "reconnection-attempt-notification": "Yhteys palvelimeen menetettiin, yritetään uudelleenyhdistämistä",
+    "reconnect-menu-triggered-notification": "Manuaalinen uudelleenyhdistäminen aloitettu - yritetään uutta yhteyttä osoitteeseen {}:{} 2 sekunnin kuluttua...",
+    "reconnect-failed-no-host-error": "Uudelleenyhdistäminen epäonnistui: palvelintietoja ei saatavilla",
+    "reconnect-failed-no-port-error": "Uudelleenyhdistäminen epäonnistui: virheellinen palvelinmääritys",
+    "reconnect-failed-error": "Uudelleenyhdistäminen epäonnistui: {}",
      "disconnection-notification": "Yhteys palvelimeen katkaistu",
      "connection-failed-notification": "Palvelimeen yhdistäminen epäonnistui",
      "connected-successful-notification": "Yhteys muodostettu palvelimeen onnistuneesti",
@@ -334,6 +338,7 @@ fi = {
      "setmediadirectories-menu-label": "Aseta median &hakemistot",
      "loadplaylistfromfile-menu-label": "&Lataa toistoluettelo tiedostosta",
      "saveplaylisttofile-menu-label": "&Tallenna toistoluettelo tiedostoon",
+     "reconnect-menu-label": "&Yhdistä palvelimeen uudelleen",
      "exit-menu-label": "P&oistu",
      "advanced-menu-label": "&Edistyneet",
      "window-menu-label": "&Ikkuna",
@@ -509,6 +514,10 @@ fi = {
     "server-startTLS-argument": "Kytke päälle TLS-yhteydet käyttäen varmennetiedostoja annetun tiedostopolkun kautta",
     "server-messed-up-motd-unescaped-placeholders": "Päivän viestissä on epäkelvot paikkamerkit. Kaikki $ merkit tulisi kaksinaistaa ($$).",
     "server-messed-up-motd-too-long": "Päivän viesti on liian pitkä - enimmäispituus on {} merkkiä, {} annettu.",
+    "server-listen-only-on-ipv4": "Kuuntele vain IPv4-osoitteilla palvelinta käynnistettäessä.",
+    "server-listen-only-on-ipv6": "Kuuntele vain IPv6-osoitteilla palvelinta käynnistettäessä.",
+    "server-interface-ipv4": "IPv4:n sidontaosoite. Tyhjäksi jättäminen käyttää oletusarvoisesti kaikkia.",
+    "server-interface-ipv6": "IPv6:n sidontaosoite. Tyhjäksi jättäminen käyttää oletusarvoisesti kaikkia.",
 
     # Server errors
     "unknown-command-server-error": "Tuntematon käsky {}",  # message

--- a/syncplay/messages_fr.py
+++ b/syncplay/messages_fr.py
@@ -25,6 +25,10 @@ fr = {
 
     "connection-attempt-notification": "Tentative de connexion à {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Connexion avec le serveur perdue, tentative de reconnexion",
+    "reconnect-menu-triggered-notification": "Reconnexion manuelle initiée - tentative de nouvelle connexion à {}:{} dans 2 secondes...",
+    "reconnect-failed-no-host-error": "Impossible de se reconnecter : aucune information de serveur disponible",
+    "reconnect-failed-no-port-error": "Impossible de se reconnecter : configuration du serveur invalide",
+    "reconnect-failed-error": "Reconnexion échouée : {}",
     "disconnection-notification": "Déconnecté du serveur",
     "connection-failed-notification": "Échec de la connexion avec le serveur",
     "connected-successful-notification": "Connexion réussie au serveur",
@@ -334,6 +338,7 @@ fr = {
     "setmediadirectories-menu-label": "Définir les &répertoires multimédias",
     "loadplaylistfromfile-menu-label": "&Charger la liste de lecture à partir du fichier",
     "saveplaylisttofile-menu-label": "&Enregistrer la liste de lecture dans un fichier",
+    "reconnect-menu-label": "&Reconnecter au serveur",
     "exit-menu-label": "Sortir",
     "advanced-menu-label": "&Avancée",
     "window-menu-label": "&Fenêtre",

--- a/syncplay/messages_it.py
+++ b/syncplay/messages_it.py
@@ -25,6 +25,10 @@ it = {
 
     "connection-attempt-notification": "Tentativo di connessione a {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Connessione col server persa, tentativo di riconnesione in corso",
+    "reconnect-menu-triggered-notification": "Riconnessione manuale avviata - tentativo di nuova connessione a {}:{} tra 2 secondi...",
+    "reconnect-failed-no-host-error": "Impossibile riconnettersi: nessuna informazione sul server disponibile",
+    "reconnect-failed-no-port-error": "Impossibile riconnettersi: configurazione del server non valida",
+    "reconnect-failed-error": "Riconnessione fallita: {}",
     "disconnection-notification": "Disconnesso dal server",
     "connection-failed-notification": "Connessione col server fallita",
     "connected-successful-notification": "Connessione al server effettuata con successo",
@@ -333,6 +337,7 @@ it = {
     "setmediadirectories-menu-label": "Imposta &cartelle multimediali",
     "loadplaylistfromfile-menu-label": "&Load playlist from file",  # TODO: Translate
     "saveplaylisttofile-menu-label": "&Save playlist to file",  # TODO: Translate
+    "reconnect-menu-label": "&Riconnetti al server",
     "exit-menu-label": "&Esci",
     "advanced-menu-label": "&Avanzate",
     "window-menu-label": "&Finestra",

--- a/syncplay/messages_ko.py
+++ b/syncplay/messages_ko.py
@@ -25,6 +25,10 @@ ko = {
 
     "connection-attempt-notification": "{}:{}에 연결을 시도 중입니다",  # Port, IP
     "reconnection-attempt-notification": "서버와의 연결이 끊어져 다시 연결을 시도 중입니다.",
+    "reconnect-menu-triggered-notification": "수동 재연결이 시작되었습니다 - 2초 후 {}:{}에 새로운 연결을 시도합니다...",
+    "reconnect-failed-no-host-error": "재연결할 수 없습니다: 서버 정보를 사용할 수 없습니다",
+    "reconnect-failed-no-port-error": "재연결할 수 없습니다: 잘못된 서버 구성입니다",
+    "reconnect-failed-error": "재연결 실패: {}",
     "disconnection-notification": "서버에서 연결이 끊어졌습니다",
     "connection-failed-notification": "서버 연결에 실패했습니다.",
     "connected-successful-notification": "서버에 성공적으로 연결했습니다",
@@ -333,6 +337,7 @@ ko = {
     "setmediadirectories-menu-label": "미디어 디렉터리 설정(&D)",
     "loadplaylistfromfile-menu-label": "파일에서 재생목록 불러오기(&L)",
     "saveplaylisttofile-menu-label": "재생목록을 파일로 저장(&S)",
+    "reconnect-menu-label": "서버에 재연결(&R)",
     "exit-menu-label": "종료(&X)",
     "advanced-menu-label": "고급(&A)",
     "window-menu-label": "창(&W)",
@@ -508,6 +513,10 @@ ko = {
     "server-startTLS-argument": "제공된 경로의 인증서 파일을 사용하여 TLS 연결 활성화",
     "server-messed-up-motd-unescaped-placeholders": "오늘의 메시지에는 이스케이프 처리되지 않은 자리 표시자가 있습니다. 모든 $ 기호는 이중($$)이어야 합니다.",
     "server-messed-up-motd-too-long": "오늘의 메시지가 너무 깁니다 - 최대 {}자, {}개까지만 허용됩니다.",
+    "server-listen-only-on-ipv4": "서버 시작 시 IPv4에서만 수신합니다.",
+    "server-listen-only-on-ipv6": "서버 시작 시 IPv6에서만 수신합니다.",
+    "server-interface-ipv4": "IPv4에 바인딩할 IP 주소입니다. 비워두면 기본적으로 모든 주소를 사용합니다.",
+    "server-interface-ipv6": "IPv6에 바인딩할 IP 주소입니다. 비워두면 기본적으로 모든 주소를 사용합니다.",
 
     # Server errors
     "unknown-command-server-error": "알 수 없는 명령 {}",  # message

--- a/syncplay/messages_pt_BR.py
+++ b/syncplay/messages_pt_BR.py
@@ -25,6 +25,10 @@ pt_BR = {
 
     "connection-attempt-notification": "Tentando se conectar a {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Conexão com o servidor perdida, tentando reconectar",
+    "reconnect-menu-triggered-notification": "Reconexão manual iniciada - será tentada uma nova conexão a {}:{} em 2 segundos...",
+    "reconnect-failed-no-host-error": "Não é possível reconectar: nenhuma informação do servidor disponível",
+    "reconnect-failed-no-port-error": "Não é possível reconectar: configuração do servidor inválida",
+    "reconnect-failed-error": "Reconexão falhou: {}",
     "disconnection-notification": "Desconectado do servidor",
     "connection-failed-notification": "Conexão com o servidor falhou",
     "connected-successful-notification": "Conectado com sucesso ao servidor",
@@ -333,6 +337,7 @@ pt_BR = {
     "setmediadirectories-menu-label": "Definir &diretórios de mídias",
     "loadplaylistfromfile-menu-label": "&Carregar playlist de arquivo",
     "saveplaylisttofile-menu-label": "&Salvar playlist em arquivo",
+    "reconnect-menu-label": "&Reconectar ao servidor",
     "exit-menu-label": "&Sair",
     "advanced-menu-label": "A&vançado",
     "window-menu-label": "&Janela",

--- a/syncplay/messages_pt_PT.py
+++ b/syncplay/messages_pt_PT.py
@@ -25,6 +25,10 @@ pt_PT = {
 
     "connection-attempt-notification": "Tentando se conectar a {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Conexão com o servidor perdida, tentando reconectar",
+    "reconnect-menu-triggered-notification": "Reconexão manual iniciada - será tentada uma nova ligação a {}:{} em 2 segundos...",
+    "reconnect-failed-no-host-error": "Não é possível reconectar: sem informações do servidor disponíveis",
+    "reconnect-failed-no-port-error": "Não é possível reconectar: configuração do servidor inválida",
+    "reconnect-failed-error": "Reconexão falhou: {}",
     "disconnection-notification": "Desconectado do servidor",
     "connection-failed-notification": "Conexão com o servidor falhou",
     "connected-successful-notification": "Conectado com sucesso ao servidor",
@@ -332,6 +336,7 @@ pt_PT = {
     "setmediadirectories-menu-label": "Definir &pastas de mídias",
     "loadplaylistfromfile-menu-label": "&Carregar playlist de ficheiro",
     "saveplaylisttofile-menu-label": "&Salvar playlist em ficheiro",
+    "reconnect-menu-label": "&Reconectar ao servidor",
     "exit-menu-label": "&Sair",
     "advanced-menu-label": "A&vançado",
     "window-menu-label": "&Janela",

--- a/syncplay/messages_ru.py
+++ b/syncplay/messages_ru.py
@@ -25,6 +25,10 @@ ru = {
 
     "connection-attempt-notification": "Подключение к {}:{}",  # Port, IP
     "reconnection-attempt-notification": "Соединение с сервером потеряно, переподключение",
+    "reconnect-menu-triggered-notification": "Ручное переподключение инициировано - попытка нового подключения к {}:{} через 2 секунды...",
+    "reconnect-failed-no-host-error": "Невозможно переподключиться: информация о сервере недоступна",
+    "reconnect-failed-no-port-error": "Невозможно переподключиться: недопустимая конфигурация сервера",
+    "reconnect-failed-error": "Переподключение не удалось: {}",
     "disconnection-notification": "Отключились от сервера",
     "connection-failed-notification": "Не удалось подключиться к серверу",
     "connected-successful-notification": "Соединение с сервером установлено",
@@ -334,6 +338,7 @@ ru = {
     "setmediadirectories-menu-label": "&Папки воспроизведения",
     "loadplaylistfromfile-menu-label": "&Загрузить список воспроизведения из файла",
     "saveplaylisttofile-menu-label": "&Сохранить список воспроизведения в файл",
+    "reconnect-menu-label": "&Переподключиться к серверу",
     "exit-menu-label": "&Выход",
     "advanced-menu-label": "&Дополнительно",
     "window-menu-label": "&Вид",

--- a/syncplay/messages_tr.py
+++ b/syncplay/messages_tr.py
@@ -25,6 +25,10 @@ tr = {
 
     "connection-attempt-notification": "{} İle bağlantı kurulmaya çalışılıyor: {}",  # Port, IP
     "reconnection-attempt-notification": "Sunucuyla bağlantı kesildi, yeniden bağlanılmaya çalışılıyor",
+    "reconnect-menu-triggered-notification": "Manuel yeniden bağlantı başlatıldı - {}:{} adresine 2 saniye içinde yeni bağlantı denenecek...",
+    "reconnect-failed-no-host-error": "Yeniden bağlanılamıyor: sunucu bilgisi mevcut değil",
+    "reconnect-failed-no-port-error": "Yeniden bağlanılamıyor: geçersiz sunucu yapılandırması",
+    "reconnect-failed-error": "Yeniden bağlantı başarısız: {}",
     "disconnection-notification": "Sunucuyla bağlantısı kesildi",
     "connection-failed-notification": "Sunucuyla bağlantı başarısız oldu",
     "connected-successful-notification": "Sunucuya başarıyla bağlandı",
@@ -334,6 +338,7 @@ tr = {
     "setmediadirectories-menu-label": "Medya di&zinlerini ayarlayın",
     "loadplaylistfromfile-menu-label": "Dosyadan oynatma &listesi yükle",
     "saveplaylisttofile-menu-label": "Oynatma listesini dosyaya kay&dedin",
+    "reconnect-menu-label": "Sunucuya &yeniden bağlan",
     "exit-menu-label": "Çı&kış",
     "advanced-menu-label": "&Gelişmiş",
     "window-menu-label": "&Pencere",

--- a/syncplay/messages_zh_CN.py
+++ b/syncplay/messages_zh_CN.py
@@ -25,6 +25,10 @@ zh_CN = {
 
     "connection-attempt-notification": "正在尝试连接{}:{}",  # Port, IP
     "reconnection-attempt-notification": "服务器连接中断，正在尝试重连",
+    "reconnect-menu-triggered-notification": "已发起手动重连 - 将在2秒后尝试连接到{}:{}...",
+    "reconnect-failed-no-host-error": "无法重连：没有可用的服务器信息",
+    "reconnect-failed-no-port-error": "无法重连：服务器配置无效",
+    "reconnect-failed-error": "重连失败：{}",
     "disconnection-notification": "与服务器连接中断",
     "connection-failed-notification": "服务器连接失败",
     "connected-successful-notification": "服务器连接成功",
@@ -334,6 +338,7 @@ zh_CN = {
     "setmediadirectories-menu-label": "设置媒体 &目录",
     "loadplaylistfromfile-menu-label": "&从文件加载播放列表",
     "saveplaylisttofile-menu-label": "&保存播放列表到文件",
+    "reconnect-menu-label": "&重新连接到服务器",
     "exit-menu-label": "退&出",
     "advanced-menu-label": "&高级",
     "window-menu-label": "&窗口",


### PR DESCRIPTION
## Summary
- Adds missing `reconnect-menu-triggered-notification`, `reconnect-failed-no-host-error`, `reconnect-failed-no-port-error`, `reconnect-failed-error`, `reconnect-menu-label` to all 12 non-English languages
- Adds missing `ready-chat-message` and `not-ready-chat-message` to Spanish
- Adds missing `server-listen-only-on-ipv4`, `server-listen-only-on-ipv6`, `server-interface-ipv4`, `server-interface-ipv6` to Finnish and Korean

These strings were identified via `getMissingStrings()` which reported them during build. After this change, `getMissingStrings()` returns empty.

Translations were done with AI assistance — native speaker review is welcome.

## Affected languages
de, eo, es, fi, fr, it, ko, pt_BR, pt_PT, ru, tr, zh_CN