### PR TITLE
skip lines starting with # for m3u8 files

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -2021,6 +2021,10 @@ class SyncplayPlaylist():
 
         with open(path) as f:
             newPlaylist = f.read().splitlines()
+            if path.lower().endswith(".m3u8"):
+                newPlaylist = [
+                    line for line in newPlaylist if line.strip() and not line.startswith("#")
+                ]
             if shuffle:
                 random.shuffle(newPlaylist)
             if newPlaylist:


### PR DESCRIPTION
Syncplay allows loading from `.m3u8` files but doesn't ignore lines starting with `#` (it treats those lines like files too)

This PR skips lines starting with `#` when loading an `.m3u8` file