### PR TITLE
Move database room deletions to be consistent with saves

### DIFF
--- a/syncplay/server.py
+++ b/syncplay/server.py
@@ -489,20 +489,16 @@ class RoomManager(object):
             if RoomPasswordProvider.isControlledRoom(roomName):
                 room = ControlledRoom(roomName, self._roomsDbHandle)
             else:
-                if roomName in self._rooms:
-                    self._deleteRoomIfEmpty(self._rooms[roomName])
                 room = Room(roomName, self._roomsDbHandle)
             self._rooms[roomName] = room
             return room
 
     def _deleteRoomIfEmpty(self, room):
+        if room.isPermanent():
+            return
+        if room.isPersistent() and not room.isPlaylistEmpty():
+            return
         if room.isEmpty() and room.getName():
-            if self._roomsDbHandle and room.isPermanent():
-                return
-            if self._roomsDbHandle and room.isNotPermanent():
-                if room.isPersistent() and not room.isPlaylistEmpty():
-                    return
-                self._roomsDbHandle.deleteRoom(room.getName())
             del self._rooms[room.getName()]
 
     def findFreeUsername(self, username, maxUsernameLength=constants.MAX_USERNAME_LENGTH):
@@ -581,8 +577,11 @@ class Room(object):
     def writeToDb(self):
         if not self.isPersistent():
             return
-        processed_playlist = getListAsMultilineString(self._playlist)
-        self._roomsDbHandle.saveRoom(self._name, processed_playlist, self._playlistIndex, self._position, self._lastSavedUpdate)
+        if self.isPlaylistEmpty():
+            self._roomsDbHandle.deleteRoom(self._name)
+        else:
+            processed_playlist = getListAsMultilineString(self._playlist)
+            self._roomsDbHandle.saveRoom(self._name, processed_playlist, self._playlistIndex, self._position, self._lastSavedUpdate)
 
     def loadRoom(self, room):
         name, playlist, playlistindex, position, lastupdate = room


### PR DESCRIPTION
Currently emptying a room with an empty playlist fires off two transactions which get run together:
- update the room db entry (with nothing useful)
- delete the room db entry

Usually the DELETE is processed first and then INSERT OR REPLACE adds the room back to the database. Although the room is gone from the GUI, it will pop back into existence when the server is restarted.

This change simplifies the logic to always delete the room from the database when the playlist is empty (regardless of whether there are watchers).