### PR TITLE
Support TLS on pyOpenSSL 26.2.0 (#774)

### DIFF
--- a/syncplay/protocols.py
+++ b/syncplay/protocols.py
@@ -401,9 +401,27 @@ class SyncClientProtocol(JSONCommandProtocol):
             self.sendHello()
             return
 
-        for x in range(0,self._serverCertificateTLS.get_extension_count()):
-            if (self._serverCertificateTLS.get_extension(x).get_short_name() == b'subjectAltName'):
-                self._subjectTLS = self._serverCertificateTLS.get_extension(x).__str__().replace("DNS:", "")
+        self._subjectTLS = ""
+        try:
+            from cryptography import x509
+            cryptographyCertificate = self._serverCertificateTLS.to_cryptography()
+            subjectAltName = cryptographyCertificate.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+            names = subjectAltName.get_values_for_type(x509.DNSName)
+            names = names + ["IP Address:{}".format(ipAddress) for ipAddress in subjectAltName.get_values_for_type(x509.IPAddress)]
+            self._subjectTLS = ", ".join([str(name) for name in names])
+        except Exception:
+            pass
+
+        if not self._subjectTLS:
+            try:
+                if hasattr(self._serverCertificateTLS, "get_extension_count") and hasattr(self._serverCertificateTLS, "get_extension"):
+                    for x in range(0,self._serverCertificateTLS.get_extension_count()):
+                        extension = self._serverCertificateTLS.get_extension(x)
+                        if extension.get_short_name() == b'subjectAltName':
+                            self._subjectTLS = str(extension).replace("DNS:", "")
+                            break
+            except Exception:
+                pass
 
         if not self._subjectTLS:
             self._subjectTLS = self._client._config.get("host", "") or ""


### PR DESCRIPTION
**Test environment:**
* Windows 10
* Python 3.8

**Before patch:**
* pyOpenSSL 26.2.0 reproduced issue #774.
* TLS handshake reached `handshakeCompleted()`, then failed with:
  AttributeError: 'X509' object has no attribute 'get_extension'

**After patch:**
* pyOpenSSL 26.2.0 connects successfully to syncplay.pl:8999.
* pyOpenSSL 25.3.0 also connects successfully to syncplay.pl:8999.
* Both successful tests reached:
  Secure connection established (TLSv1.3)
  Successfully connected to server