### PR TITLE
Update CI actions to Node.js 24-compatible releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
           architecture: x86
@@ -48,14 +48,14 @@ jobs:
         run: dir
 
       - name: Deploy portable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Syncplay_${{ env.VER }}_Portable
           path: |
             syncplay_v${{ env.VER }}
 
       - name: Deploy installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Syncplay-${{ env.VER }}-Setup.exe
           path: |
@@ -66,7 +66,7 @@ jobs:
     runs-on: macos-15-intel
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup Python
         run: |
@@ -131,7 +131,7 @@ jobs:
           ls -al dist_actions
 
       - name: Deploy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Syncplay_${{ env.VER }}.dmg
           path: |
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Build
         run: ci/deb-script.sh
@@ -164,14 +164,14 @@ jobs:
           ls -al dist_actions
 
       - name: Deploy full deb
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: syncplay.deb
           path: |
             dist_actions/syncplay_*.deb
 
       - name: Deploy server deb
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: syncplay-server.deb
           path: |


### PR DESCRIPTION
Designed to resolve the following CI build warning:

`node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v2, actions/setup-python@v2, actions/upload-artifact@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`