### PR TITLE
Fix GUI crash when opening a file before the media player is ready

### DIFF
--- a/syncplay/client.py
+++ b/syncplay/client.py
@@ -619,6 +619,10 @@ class SyncplayClient(object):
             self.playlist.loadPlaylistFromFile(filePath, resetPosition)
             return
 
+        if self.playerIsNotReady():
+            self.ui.showErrorMessage(getMessage("player-not-ready-error"))
+            return
+
         self.playlist.openedFile()
         self._player.openFile(filePath, resetPosition)
         if resetPosition:

--- a/syncplay/messages_en.py
+++ b/syncplay/messages_en.py
@@ -139,6 +139,7 @@ en = {
     "mpv-failed-advice": "The reason mpv cannot start may be due to the use of unsupported command line arguments or an unsupported version of mpv.",
     "player-file-open-error": "Player failed opening file",
     "player-path-error": "Player path is not set properly. Supported players are: mpv, mpv.net, VLC, MPC-HC, MPC-BE, mplayer2, and IINA",
+    "player-not-ready-error": "Media player is not ready yet. Please wait for it to finish starting up and try again.",
     "hostname-empty-error": "Hostname can't be empty",
     "empty-error": "{} can't be empty",  # Configuration
     "media-player-error": "Media player error: \"{}\"",  # Error line

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -1067,6 +1067,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @needsClient
     def browseMediapath(self):
+        if self._syncplayClient.playerIsNotReady():
+            self.showErrorMessage(getMessage("player-not-ready-error"))
+            return
         if self._syncplayClient._player.customOpenDialog == True:
             self._syncplayClient._player.openCustomOpenDialog()
             return
@@ -1096,6 +1099,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @needsClient
     def OpenAddFilesToPlaylistDialog(self):
+        if self._syncplayClient.playerIsNotReady():
+            self.showErrorMessage(getMessage("player-not-ready-error"))
+            return
         if self._syncplayClient._player.customOpenDialog == True:
             self._syncplayClient._player.openCustomOpenDialog()
             return


### PR DESCRIPTION
Fixes #787 and #786.

`browseMediapath()`, `OpenAddFilesToPlaylistDialog()`, and `SyncplayClient.openFile()` all touch `self._player` without checking if it's `None`. It stays `None` until the player process actually launches and connects back (`SyncplayClient.initPlayer`), so opening a file, adding to the playlist, or double-clicking a playlist entry before that happens crashes with:

```
AttributeError: 'NoneType' object has no attribute 'customOpenDialog'
AttributeError: 'NoneType' object has no attribute 'openFile'
```

That's guaranteed if the player fails to launch at all (both linked issues), but it can also happen with a working player if you click fast enough right after startup - I hit the `openFile` one by accident just double-clicking a playlist entry while testing the other two.

Added a `playerIsNotReady()` check before each one and show a message instead of crashing.

Test plan:
- [x] Reproduced all three crashes with a player path that always fails to start
- [x] Confirmed the fix on all three (message shown, no crash) against the same setup
- [x] Clicked through it manually in the built GUI - Open Media File, Add files to playlist, and double-clicking a playlist entry