### PR TITLE
Move Windows build to 64-bit PySide6 to resolve high-DPI/scaling issue (fixes #793 by SquirrelKiev and #707 by ritiek)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           pip3 install -U setuptools wheel pip
           pip3 install -r requirements.txt
           pip3 install "PySide6-Essentials>=6.11,<6.12"
-          pip3 install "py2exe==0.14.2.0"
+          pip3 install "py2exe==0.14.0.0"
 
       - name: Check Python dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,13 @@ jobs:
           python3 -c "from PySide6.QtCore import __version__; print(__version__)"
           python3 -c "from PySide6.QtCore import QLibraryInfo; print(QLibraryInfo.path(QLibraryInfo.LibrariesPath))"
           python3 -c "import py2exe; print(py2exe.__version__)"
+          
+      - name: Check PySide6 Windows plugins
+        shell: pwsh
+        run: |
+          $plugins = python -c "from PySide6.QtCore import QLibraryInfo; print(QLibraryInfo.path(QLibraryInfo.PluginsPath))"
+          Write-Host "PySide6 plugin directory: $plugins"
+          Get-ChildItem "$plugins\styles"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,12 +96,6 @@ jobs:
           python3 -c "from PySide6.QtCore import QLibraryInfo; print(QLibraryInfo.path(QLibraryInfo.LibrariesPath))"
           python3 -c "import py2exe; print(py2exe.__version__)"
           
-      - name: Check PySide6 Windows plugins
-        shell: pwsh
-        run: |
-          $plugins = python -c "from PySide6.QtCore import QLibraryInfo; print(QLibraryInfo.path(QLibraryInfo.PluginsPath))"
-          Write-Host "PySide6 plugin directory: $plugins"
-          Get-ChildItem "$plugins\styles"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  windows:
-    name: Build for Windows
+  windows32:
+    name: Build for Windows (32-bit legacy)
     runs-on: windows-2022
     steps:
       - name: Checkout
@@ -50,14 +50,84 @@ jobs:
       - name: Deploy portable
         uses: actions/upload-artifact@v6
         with:
-          name: Syncplay_${{ env.VER }}_Portable
+          name: Syncplay_${{ env.VER }}_x86_Portable
           path: |
             syncplay_v${{ env.VER }}
 
       - name: Deploy installer
         uses: actions/upload-artifact@v6
         with:
-          name: Syncplay-${{ env.VER }}-Setup.exe
+          name: Syncplay-${{ env.VER }}-x86-Setup.exe
+          path: |
+            Syncplay-${{ env.VER }}-Setup.exe
+
+  windows64:
+    name: Build for Windows (64-bit PySide6)
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          architecture: x64
+
+      - name: Check Python install
+        run: |
+          which python
+          python --version
+          python -c "import struct; print(struct.calcsize('P') * 8)"
+          which pip
+          pip --version
+
+      - name: Install Python dependencies
+        run: |
+          pip3 install -U setuptools wheel pip
+          pip3 install -r requirements.txt
+          pip3 install "PySide6-Essentials>=6.11,<6.12"
+          pip3 install "py2exe==0.14.2.0"
+
+      - name: Check Python dependencies
+        run: |
+          python3 -c "from PySide6 import __version__; print(__version__)"
+          python3 -c "from PySide6.QtCore import __version__; print(__version__)"
+          python3 -c "from PySide6.QtCore import QLibraryInfo; print(QLibraryInfo.path(QLibraryInfo.LibrariesPath))"
+          python3 -c "import py2exe; print(py2exe.__version__)"
+
+      - name: Build
+        run: |
+          $ver = (findstr version .\syncplay\__init__.py).split("'")[1]
+          echo $ver
+          echo "VER=$ver" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          python buildPy2exe.py
+          New-Item -Path syncplay_v$ver -Name "syncplay.ini" -Value " "
+
+      - name: Test packaged GUI startup
+        shell: pwsh
+        run: |
+          $process = Start-Process -FilePath ".\syncplay_v${{ env.VER }}\Syncplay.exe" -PassThru
+          Start-Sleep -Seconds 5
+          if ($process.HasExited) {
+            throw "Packaged Syncplay.exe exited during startup with code $($process.ExitCode)"
+          }
+          Stop-Process -Id $process.Id -Force
+
+      - name: Prepare for deployment
+        run: dir
+
+      - name: Deploy portable
+        uses: actions/upload-artifact@v6
+        with:
+          name: Syncplay_${{ env.VER }}_x64_Portable
+          path: |
+            syncplay_v${{ env.VER }}
+
+      - name: Deploy installer
+        uses: actions/upload-artifact@v6
+        with:
+          name: Syncplay-${{ env.VER }}-x64-Setup.exe
           path: |
             Syncplay-${{ env.VER }}-Setup.exe
 

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -29,6 +29,56 @@ except ImportError:
 import syncplay
 from syncplay.messages import getMissingStrings, getMessage, getLanguages
 
+try:
+    import PySide6
+    from PySide6 import QtCore as BuildQtCore
+    QT_BINDING = 'PySide6'
+    QT_PACKAGES = 'PySide6, shiboken6'
+except ImportError:
+    from PySide2 import QtCore as BuildQtCore
+    QT_BINDING = 'PySide2'
+    QT_PACKAGES = 'PySide2'
+
+
+def installPySide6Py2exeHook():
+    if QT_BINDING != 'PySide6':
+        return
+
+    import ast
+    from py2exe import hooks as py2exeHooks
+
+    qtModules = list(PySide6.__all__)
+
+    def hookPySide6(finder, module):
+        tree = ast.parse(module.__source__)
+        foundModuleFinder = [False]
+        foundDirectorySetup = [False]
+
+        class ChangeDef(ast.NodeTransformer):
+            def visit_FunctionDef(self, node):
+                if node.name == '_find_all_qt_modules':
+                    node.body = ast.parse('return {!r}'.format(qtModules)).body
+                    foundModuleFinder[0] = True
+                elif node.name == '_setupQtDirectories':
+                    node.body = ast.parse(
+                        'global Shiboken\nfrom shiboken6 import Shiboken'
+                    ).body
+                    foundDirectorySetup[0] = True
+                return node
+
+        patchedTree = ast.fix_missing_locations(ChangeDef().visit(tree))
+        if not foundModuleFinder[0] or not foundDirectorySetup[0]:
+            raise RuntimeError('PySide6 package layout is not compatible with the py2exe build workaround')
+        module.__code_object__ = compile(
+            patchedTree, module.__file__, 'exec', optimize=module.__optimize__
+        )
+        finder.import_hook('shiboken6')
+
+    py2exeHooks.hook_PySide6 = hookPySide6
+
+
+installPySide6Py2exeHook()
+
 missingStrings = getMissingStrings()
 if missingStrings is not None and missingStrings != "":
     import warnings
@@ -594,6 +644,10 @@ class NSISScript(object):
         return "\n".join(delete)
 
 def pruneUnneededLibraries():
+    if QT_BINDING != 'PySide2':
+        print('*** skipping Qt library pruning for PySide6 build ***')
+        return
+
     from pathlib import Path
     cwd = os.getcwd()
     libDir = cwd + '\\' + OUT_DIR + '\\lib\\'
@@ -621,8 +675,10 @@ def pruneUnneededLibraries():
 
 def copyQtPlugins(paths):
     import shutil
-    from PySide2 import QtCore
-    basePath = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.PluginsPath)
+    if QT_BINDING == 'PySide6':
+        basePath = BuildQtCore.QLibraryInfo.path(BuildQtCore.QLibraryInfo.PluginsPath)
+    else:
+        basePath = BuildQtCore.QLibraryInfo.location(BuildQtCore.QLibraryInfo.PluginsPath)
     basePath = basePath.replace('/', '\\')
     destBase = os.getcwd() + '\\' + OUT_DIR
     for elem in paths:
@@ -678,7 +734,7 @@ info = dict(
     options={
         'py2exe': {
             'dist_dir': OUT_DIR,
-            'packages': 'PySide2, cffi, OpenSSL, certifi',
+            'packages': '{}, cffi, OpenSSL, certifi'.format(QT_PACKAGES),
             'includes': 'twisted, sys, encodings, datetime, os, time, math, urllib, ast, unicodedata, _ssl, win32pipe, win32file, sqlite3',
             'excludes': 'venv, doctest, pdb, unittest, win32clipboard, win32pdh, win32security, win32trace, win32ui, winxpgui, win32process, tcl, tkinter',
             'dll_excludes': 'msvcr71.dll, MSVCP90.dll, POWRPROF.dll',

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -713,7 +713,7 @@ resources.extend(guiIcons)
 intf_resources = ["syncplay/resources/lua/intf/syncplay.lua"]
 
 if QT_BINDING == 'PySide6':
-    qt_plugins = ['platforms\\qwindows.dll']
+    qt_plugins = ['platforms\\qwindows.dll', 'styles\\qmodernwindowsstyle.dll']
 else:
     qt_plugins = ['platforms\\qwindows.dll', 'styles\\qwindowsvistastyle.dll']
 

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -640,7 +640,7 @@ class NSISScript(object):
         for dir_ in fileList.keys():
             for file_ in fileList[dir_]:
                 delete.append('DELETE "$INSTDIR\\{}\\{}"'.format(dir_, file_))
-            delete.append('RMdir "$INSTDIR\\{}"'.format(file_))
+            delete.append('RMdir "$INSTDIR\\{}"'.format(dir_))
         return "\n".join(delete)
 
 def pruneUnneededLibraries():

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -102,6 +102,7 @@ NSIS_COMPILE = get_nsis_path()
 
 OUT_DIR = "syncplay_v{}".format(syncplay.version)
 SETUP_SCRIPT_PATH = "syncplay_setup.nsi"
+DEFAULT_INSTALL_DIR = "$PROGRAMFILES64\\Syncplay" if sys.maxsize > 2**32 else "$PROGRAMFILES\\Syncplay"
 
 languages = getLanguages()
 
@@ -172,7 +173,8 @@ NSIS_SCRIPT_TEMPLATE = r"""
 
   Name "Syncplay $version"
   OutFile "Syncplay-$version-Setup.exe"
-  InstallDir $$PROGRAMFILES\Syncplay
+  InstallDir "$installDir"
+  InstallDirRegKey HKLM SOFTWARE\Syncplay "Install_Dir"
   RequestExecutionLevel admin
   ManifestDPIAware true
   XPStyle on
@@ -598,6 +600,7 @@ class NSISScript(object):
             raise RuntimeError("Cannot create setup script, file exists at {}".format(SETUP_SCRIPT_PATH))
         contents = Template(NSIS_SCRIPT_TEMPLATE).substitute(
             version=syncplay.version,
+            installDir=DEFAULT_INSTALL_DIR,
             uninstallFiles=uninstallFiles,
             installFiles=installFiles,
             totalSize=totalSize,

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -644,10 +644,6 @@ class NSISScript(object):
         return "\n".join(delete)
 
 def pruneUnneededLibraries():
-    if QT_BINDING != 'PySide2':
-        print('*** skipping Qt library pruning for PySide6 build ***')
-        return
-
     from pathlib import Path
     cwd = os.getcwd()
     libDir = cwd + '\\' + OUT_DIR + '\\lib\\'
@@ -667,8 +663,21 @@ def pruneUnneededLibraries():
                     'Qt5WebEngineCore.dll', 'Qt5WebEngineWidgets.dll', 'Qt5WebSockets.dll', 'Qt5WinExtras.dll', 'Qt5Xml.dll',
                     'Qt5XmlPatterns.dll']
     windowsDLL = ['MSVCP140.dll', 'VCRUNTIME140.dll']
+    if QT_BINDING == 'PySide6':
+        unneededModules = ['PySide6.QtConcurrent.pyd', 'PySide6.QtDesigner.pyd', 'PySide6.QtHelp.pyd',
+                           'PySide6.QtOpenGL.pyd', 'PySide6.QtOpenGLWidgets.pyd', 'PySide6.QtPrintSupport.pyd',
+                           'PySide6.QtQml.pyd', 'PySide6.QtQuick.pyd', 'PySide6.QtQuickControls2.pyd',
+                           'PySide6.QtQuickTest.pyd', 'PySide6.QtQuickWidgets.pyd', 'PySide6.QtSql.pyd',
+                           'PySide6.QtSvg.pyd', 'PySide6.QtSvgWidgets.pyd', 'PySide6.QtTest.pyd',
+                           'PySide6.QtUiTools.pyd', 'PySide6.QtXml.pyd']
+        unneededLibs = ['Qt6Concurrent.dll', 'Qt6Designer.dll', 'Qt6Help.dll', 'Qt6OpenGL.dll', 'Qt6OpenGLWidgets.dll',
+                        'Qt6PrintSupport.dll', 'Qt6Qml.dll', 'Qt6Quick.dll', 'Qt6QuickControls2.dll', 'Qt6QuickTest.dll',
+                        'Qt6QuickWidgets.dll', 'Qt6Sql.dll', 'Qt6Svg.dll', 'Qt6SvgWidgets.dll', 'Qt6Test.dll',
+                        'Qt6UiTools.dll', 'Qt6Xml.dll']
+        windowsDLL = []
     deleteList = unneededModules + unneededLibs + windowsDLL
-    deleteList.append('api-*')
+    if QT_BINDING == 'PySide2':
+        deleteList.append('api-*')
     for filename in deleteList:
         for p in Path(libDir).glob(filename):
             p.unlink()

--- a/buildPy2exe.py
+++ b/buildPy2exe.py
@@ -712,7 +712,11 @@ resources = [
 resources.extend(guiIcons)
 intf_resources = ["syncplay/resources/lua/intf/syncplay.lua"]
 
-qt_plugins = ['platforms\\qwindows.dll', 'styles\\qwindowsvistastyle.dll']
+if QT_BINDING == 'PySide6':
+    qt_plugins = ['platforms\\qwindows.dll']
+else:
+    qt_plugins = ['platforms\\qwindows.dll', 'styles\\qwindowsvistastyle.dll']
+
 
 common_info = dict(
     name='Syncplay',

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -15,13 +15,14 @@ from syncplay.vendor.Qt import QtCore, QtWidgets, QtGui, __binding__, IsPySide, 
 from syncplay.vendor.Qt.QtCore import Qt, QSettings, QCoreApplication, QSize, QPoint, QUrl, QLine, QEventLoop, Signal
 from syncplay.vendor.Qt.QtWidgets import QApplication, QLineEdit, QLabel, QCheckBox, QButtonGroup, QRadioButton, QDoubleSpinBox, QPlainTextEdit
 from syncplay.vendor.Qt.QtGui import QCursor, QIcon, QImage, QDesktopServices
-try:
-    if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
-        QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
-except AttributeError:
-    pass  # To ignore error "Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created"
-if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
+if not IsPySide6:
+    try:
+        if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
+            QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    except AttributeError:
+        pass  # To ignore error "Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created"
+    if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
+        QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
 if IsPySide6:
     from PySide6.QtCore import QStandardPaths
 elif IsPySide2:

--- a/syncplay/ui/GuiConfiguration.py
+++ b/syncplay/ui/GuiConfiguration.py
@@ -1128,13 +1128,19 @@ class ConfigDialog(QtWidgets.QDialog):
             font = QtGui.QFont()
             font.setFamily(self.config[configName + "FontFamily"])
             font.setPointSize(self.config[configName + "RelativeFontSize"])
-            font.setWeight(self.config[configName + "FontWeight"])
+            if IsPySide6:
+                font.setLegacyWeight(int(self.config[configName + "FontWeight"]))
+            else:
+                font.setWeight(self.config[configName + "FontWeight"])
             font.setUnderline(self.config[configName + "FontUnderline"])
             ok, value = QtWidgets.QFontDialog.getFont(font)
             if ok:
                 self.config[configName + "FontFamily"] = value.family()
                 self.config[configName + "RelativeFontSize"] = value.pointSize()
-                self.config[configName + "FontWeight"] = value.weight()
+                if IsPySide6:
+                    self.config[configName + "FontWeight"] = value.legacyWeight()
+                else:
+                    self.config[configName + "FontWeight"] = value.weight()
                 self.config[configName + "FontUnderline"] = value.underline()
 
     def colourDialog(self, configName):

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -2174,7 +2174,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.loadSettings()
         self.setWindowIcon(QtGui.QPixmap(resourcespath + "syncplay.png"))
         if isWindows() and IsPySide6:
-            self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+            self.setWindowFlags(Qt.Window | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowMinimizeButtonHint | Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
         else:
             self.setWindowFlags(self.windowFlags() & Qt.WindowCloseButtonHint & Qt.WindowMinimizeButtonHint & ~Qt.WindowContextHelpButtonHint)
         self.show()

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -26,13 +26,14 @@ if isLinux():
     applyDPIScaling = False
 else:
     applyDPIScaling = True
-try:
-    if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
-        QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, applyDPIScaling)
-except AttributeError:
-    pass  # To ignore error "Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created"
-if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, applyDPIScaling)
+if not IsPySide6:
+    try:
+        if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
+            QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, applyDPIScaling)
+    except AttributeError:
+        pass  # To ignore error "Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created"
+    if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
+        QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, applyDPIScaling)
 if IsPySide6:
     from PySide6.QtCore import QStandardPaths
 elif IsPySide2:

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -1193,7 +1193,10 @@ class MainWindow(QtWidgets.QMainWindow):
         URIsLayout.addWidget(URIsButtonBox, 2, 0, 1, 1)
         URIsDialog.setLayout(URIsLayout)
         URIsDialog.setModal(True)
-        URIsDialog.setWindowFlags(URIsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            URIsDialog.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
+        else:
+            URIsDialog.setWindowFlags(URIsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         URIsDialog.show()
         result = URIsDialog.exec_()
         if result == QtWidgets.QDialog.Accepted:
@@ -1224,7 +1227,10 @@ class MainWindow(QtWidgets.QMainWindow):
         RoomsLayout.addWidget(RoomsButtonBox, 2, 0, 1, 1)
         RoomsDialog.setLayout(RoomsLayout)
         RoomsDialog.setModal(True)
-        RoomsDialog.setWindowFlags(RoomsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            RoomsDialog.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
+        else:
+            RoomsDialog.setWindowFlags(RoomsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         RoomsDialog.show()
         result = RoomsDialog.exec_()
         if result == QtWidgets.QDialog.Accepted:
@@ -1259,7 +1265,10 @@ class MainWindow(QtWidgets.QMainWindow):
         editPlaylistDialog.setModal(True)
         editPlaylistDialog.setMinimumWidth(600)
         editPlaylistDialog.setMinimumHeight(500)
-        editPlaylistDialog.setWindowFlags(editPlaylistDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            editPlaylistDialog.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
+        else:
+            editPlaylistDialog.setWindowFlags(editPlaylistDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         editPlaylistDialog.show()
         result = editPlaylistDialog.exec_()
         if result == QtWidgets.QDialog.Accepted:
@@ -1290,7 +1299,10 @@ class MainWindow(QtWidgets.QMainWindow):
         MediaDirectoriesAddFolderButton.pressed.connect(lambda: self.openAddMediaDirectoryDialog(MediaDirectoriesTextbox, MediaDirectoriesDialog))
         MediaDirectoriesLayout.addWidget(MediaDirectoriesAddFolderButton, 1, 1, 1, 1, Qt.AlignTop)
         MediaDirectoriesDialog.setLayout(MediaDirectoriesLayout)
-        MediaDirectoriesDialog.setWindowFlags(MediaDirectoriesDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            MediaDirectoriesDialog.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
+        else:
+            MediaDirectoriesDialog.setWindowFlags(MediaDirectoriesDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         MediaDirectoriesDialog.setModal(True)
         MediaDirectoriesDialog.show()
         result = MediaDirectoriesDialog.exec_()
@@ -1316,7 +1328,10 @@ class MainWindow(QtWidgets.QMainWindow):
         TrustedDomainsButtonBox.rejected.connect(TrustedDomainsDialog.reject)
         TrustedDomainsLayout.addWidget(TrustedDomainsButtonBox, 2, 0, 1, 1)
         TrustedDomainsDialog.setLayout(TrustedDomainsLayout)
-        TrustedDomainsDialog.setWindowFlags(TrustedDomainsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            TrustedDomainsDialog.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint)
+        else:
+            TrustedDomainsDialog.setWindowFlags(TrustedDomainsDialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         TrustedDomainsDialog.setModal(True)
         TrustedDomainsDialog.show()
         result = TrustedDomainsDialog.exec_()
@@ -2144,7 +2159,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.QtGui = QtGui
         if isMacOS():
             self.setWindowFlags(self.windowFlags())
-        else:
+        elif not (isWindows() and IsPySide6):
             try:    
                 self.setWindowFlags(self.windowFlags() & Qt.AA_DontUseNativeMenuBar)
             except TypeError:
@@ -2158,7 +2173,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addMainFrame(self)
         self.loadSettings()
         self.setWindowIcon(QtGui.QPixmap(resourcespath + "syncplay.png"))
-        self.setWindowFlags(self.windowFlags() & Qt.WindowCloseButtonHint & Qt.WindowMinimizeButtonHint & ~Qt.WindowContextHelpButtonHint)
+        if isWindows() and IsPySide6:
+            self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        else:
+            self.setWindowFlags(self.windowFlags() & Qt.WindowCloseButtonHint & Qt.WindowMinimizeButtonHint & ~Qt.WindowContextHelpButtonHint)
         self.show()
         self.setAcceptDrops(True)
         self.clearedPlaylistNote = False

--- a/syncplay/ui/gui.py
+++ b/syncplay/ui/gui.py
@@ -144,7 +144,10 @@ class AboutDialog(QtWidgets.QDialog):
         else:
             self.setWindowTitle(getMessage("about-dialog-title"))
             if isWindows():
-                self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+                if IsPySide6:
+                    self.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint  | Qt.CustomizeWindowHint                        )
+                else:
+                    self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowIcon(QtGui.QPixmap(resourcespath + 'syncplay.png'))
         nameLabel = QtWidgets.QLabel("<center><strong>Syncplay</strong></center>")
         nameLabel.setFont(QtGui.QFont("Helvetica", 18))
@@ -207,7 +210,10 @@ class CertificateDialog(QtWidgets.QDialog):
         else:
             self.setWindowTitle(getMessage("tls-information-title"))
             if isWindows():
-                self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+                if IsPySide6:
+                    self.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint  | Qt.CustomizeWindowHint                        )
+                else:
+                    self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowIcon(QtGui.QPixmap(resourcespath + 'syncplay.png'))
         statusLabel = QtWidgets.QLabel(getMessage("tls-dialog-status-label").format(tlsData["subject"]))
         descLabel = QtWidgets.QLabel(getMessage("tls-dialog-desc-label").format(tlsData["subject"]))


### PR DESCRIPTION
Adds a new 64-bit Windows build using Python 3.11 and PySide6, resolving the Windows high-DPI/scaling issue reported in #793 by @SquirrelKiev. 

As part of this work I also resolves the same issue that @ritiek was trying to fix in #707 about the invocation of the font dialogue being broken in PySide6. The holding issue on that PR was that the change didn't work on PySide2.

The existing 32-bit Python 3.8 / PySide2 build is retained as a fallback for now, but might be removed in the future.

## Summary

- Add a parallel Windows x64 build using:
  - Python 3.11
  - PySide6
  - py2exe 0.14.0.0
- Keep the existing Windows x86 / PySide2 build unchanged.
- Update `buildPy2exe.py` to support packaging either PySide2 or PySide6.
- Package the Qt6 Windows platform and modern Windows style plugins.
- Use Qt6's native high-DPI handling rather than applying the old Qt5 high-DPI attributes.
- Fix PySide6 handling of persisted `QFont` weights (resolving the issue of #707 without the compatability issues).
- Fix Windows/Qt6 window flags for the main window and custom dialogs.
- Prune unused Qt6 libraries from the packaged build.
- Add a packaged x64 GUI startup smoke test to the Windows build workflow.
- Fix generated Windows uninstaller directory removal.
- For fresh x64 installations, default to the native 64-bit Program Files directory.
- When upgrading an existing installation, continue using its registered installation directory